### PR TITLE
Handle NaN sorting and normalize sidecar paths

### DIFF
--- a/ck-ann/src/lib.rs
+++ b/ck-ann/src/lib.rs
@@ -69,7 +69,11 @@ impl AnnIndex for SimpleIndex {
             })
             .collect();
         
-        similarities.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap());
+        similarities.sort_by(|a, b| {
+            b.1
+                .partial_cmp(&a.1)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
         similarities.truncate(topk);
         similarities
     }

--- a/ck-core/src/lib.rs
+++ b/ck-core/src/lib.rs
@@ -185,7 +185,11 @@ pub fn get_sidecar_path(repo_root: &Path, file_path: &Path) -> PathBuf {
     let relative = file_path.strip_prefix(repo_root).unwrap_or(file_path);
     let mut sidecar = repo_root.join(".ck");
     sidecar.push(relative);
-    sidecar.set_extension(format!("{}.ck", relative.extension().unwrap_or_default().to_string_lossy()));
+    let ext = relative
+        .extension()
+        .map(|e| format!("{}.ck", e.to_string_lossy()))
+        .unwrap_or_else(|| "ck".to_string());
+    sidecar.set_extension(ext);
     sidecar
 }
 
@@ -297,7 +301,7 @@ mod tests {
         let file_path = PathBuf::from("/project/README");
         
         let sidecar = get_sidecar_path(&repo_root, &file_path);
-        let expected = PathBuf::from("/project/.ck/README..ck");
+        let expected = PathBuf::from("/project/.ck/README.ck");
         
         assert_eq!(sidecar, expected);
     }

--- a/ck-search/src/lib.rs
+++ b/ck-search/src/lib.rs
@@ -716,7 +716,11 @@ async fn hybrid_search_with_progress(options: &SearchOptions, progress_callback:
         .collect();
     
     // Sort by RRF score (highest first)
-    rrf_results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap());
+    rrf_results.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
     
     if let Some(top_k) = options.top_k {
         rrf_results.truncate(top_k);

--- a/test_ck_simple.sh
+++ b/test_ck_simple.sh
@@ -63,11 +63,13 @@ echo "      ck Test Suite (Simplified)"
 echo "========================================="
 echo ""
 
-# Check if binary exists
+# Check if binary exists; build if missing
 if [ ! -f "$CK_BIN" ]; then
-    echo -e "${RED}Error: ck binary not found at $CK_BIN${NC}"
-    echo "Please run: cargo build"
-    exit 1
+    echo -e "${YELLOW}ck binary not found at $CK_BIN, attempting to build...${NC}"
+    if ! cargo build >/dev/null 2>&1; then
+        echo -e "${RED}Error: build failed${NC}"
+        exit 1
+    fi
 fi
 
 echo "Using binary: $CK_BIN"


### PR DESCRIPTION
## Summary
- guard ANN and RRF sorting against NaN scores
- generate `.ck` sidecars without double dots for extensionless files
- let the simple test script auto-build the binary if missing

## Testing
- `cargo test -p ck-core`
- `cargo test` *(fails: ort-sys cannot download ONNX Runtime)*
- `./test_ck_simple.sh` *(fails: build failed, ck binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b9b8c3b52c832298006fdf06a332ef