### PR TITLE
Fix hybrid search to use consistent v3 semantic indexing

### DIFF
--- a/ck-search/src/lib.rs
+++ b/ck-search/src/lib.rs
@@ -714,7 +714,7 @@ async fn hybrid_search_with_progress(options: &SearchOptions, progress_callback:
     if let Some(ref callback) = progress_callback {
         callback("Running semantic search...");
     }
-    let semantic_results = semantic_search_with_progress(options, progress_callback).await?;
+    let semantic_results = semantic_search_v3_with_progress(options, progress_callback).await?;
     
     let mut combined = HashMap::new();
     


### PR DESCRIPTION
Hybrid search was using the legacy semantic_search_with_progress function which builds embeddings on-the-fly, while semantic search uses the more efficient semantic_search_v3_with_progress that reads pre-computed embeddings from sidecar files.

This change ensures hybrid search uses the same idempotent, hash-based indexing strategy as semantic search, eliminating redundant index rebuilds and improving performance consistency.

🤖 Generated with [Claude Code](https://claude.ai/code)