### PR TITLE
Fix UTF-8 boundary panic in preview truncation

### DIFF
--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -305,8 +305,9 @@ async fn inspect_file_metadata(file_path: &PathBuf, status: &StatusReporter) -> 
         ));
         
         // Show preview of chunk content (first 100 chars)
-        let preview = if chunk.text.len() > 100 {
-            format!("{}...", &chunk.text[..100])
+        let preview = if chunk.text.chars().count() > 100 {
+            let truncated: String = chunk.text.chars().take(100).collect();
+            format!("{}...", truncated)
         } else {
             chunk.text.clone()
         };


### PR DESCRIPTION
## Summary
• Fix panic when truncating text containing emojis or multi-byte UTF-8 characters  
• Replace unsafe `&text[..100]` byte slicing with safe character-aware truncation
• Prevents "byte index 100 is not a char boundary" panic

## Problem
Community reported panic when `--inspect` command encounters emojis at truncation boundary:
```
thread 'main' panicked at ck-cli/src/main.rs:305:41: byte index 100 is not a char boundary
```

## Solution
```rust
// Before (unsafe)
&chunk.text[..100]

// After (safe)
chunk.text.chars().take(100).collect()
```

## Test plan
- [x] Verified with emoji-containing file - no more panics
- [x] Truncation still works correctly for ASCII text
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)