### PR TITLE
Do not require skipped minimal-versions job in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
     permissions:
       contents: none
     name: CI
-    needs: [test, msrv, lockfile, rustfmt, clippy, minimal-versions]
+    needs: [test, msrv, lockfile, rustfmt, clippy]
     runs-on: ubuntu-latest
     if: "always()"
     steps:


### PR DESCRIPTION
Allows the pipeline to pass even though the minimal-versions job is skipped until the build failure can be resolved. I missed removing this when I marked the job as skipped, so right now the pipeline is marked as failing even if all non-skipped jobs pass.