### PR TITLE
feat: add JSONL output format for AI agent workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,24 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.4.0] - 2025-09-10
+## [0.4.1] - 2025-09-10
 
 ### Added
-- **Ctrl+C interrupt handling**: Comprehensive SIGINT support for safely stopping long-running indexing operations
-- **Cross-platform signal handling**: Uses `ctrlc` crate for Windows, macOS, and Linux compatibility
-- **Thread-safe interrupts**: Atomic bool operations ensure safe concurrent interrupt handling
-- **Progress preservation**: Shows count of processed files when indexing is interrupted
-- **Clean user messaging**: User-friendly interrupt notifications and graceful cleanup
+- **JSONL output format**: Stream-friendly `--jsonl` flag for AI agent workflows with structured output
+- **No-snippet mode**: `--no-snippet` flag for metadata-only output to reduce bandwidth for agents
+- **Agent documentation**: Comprehensive README section explaining JSONL benefits over traditional JSON
+- **Agent examples**: Python code demonstrating stream processing patterns for AI workflows
+- **UTF-8 warning suppression**: Eliminated noisy warnings for binary files in .git directories
 
 ### Technical
-- **Global interrupt flag**: `AtomicBool` with `std::sync::Once` pattern for one-time signal handler registration
-- **Strategic interrupt checks**: Placed throughout sequential and parallel indexing loops for responsive interruption
-- **Non-blocking design**: Interrupt checks don't impact indexing performance
-- **Dependencies**: Added `ctrlc = "3.4"` to workspace and `ck-index` crate
+- **JsonlSearchResult struct**: New agent-friendly output format with conversion methods
+- **Extended SearchResult**: Added chunk_hash and index_epoch fields for future agent features
+- **Comprehensive test coverage**: 4 new integration tests validating JSONL functionality
+- **Updated help text**: Dedicated JSONL section explaining streaming benefits for agents
+- **Phase 1 PRD**: Complete specification for agent-ready code navigation features
 
-### Fixed
-- **ONNX runtime test failures**: Resolved conflicting system-level ONNX runtime from brew-installed pytorch package
-- **Test stability**: All 65+ tests now pass cleanly without schema registration errors or mutex lock failures
+### Why JSONL for AI Agents?
+- **Streaming friendly**: Process results as they arrive, no waiting for complete response
+- **Memory efficient**: Parse one result at a time, not entire array into memory
+- **Error resilient**: Malformed lines don't break entire response
+- **Standard format**: Used by OpenAI, Anthropic, and modern ML pipelines
 
 ## [0.3.9] - 2025-09-10
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ This file contains project-specific instructions for Claude and other AI agents 
 
 ```bash
 # Correct format (current standard since 0.3.8+)
-git tag 0.4.0
+git tag 0.4.1
 git tag 0.3.9
 
 # Old format (deprecated, do not use)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,3 +81,5 @@ Always update CHANGELOG.md with new releases. Follow this structure:
 - All tests must pass
 - New features require comprehensive test coverage
 - Breaking changes require major version bump
+- --help reflects any new features
+- README incorporates any new user features (e.g. flags etc)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -405,7 +405,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "ck-ann"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -416,7 +416,7 @@ dependencies = [
 
 [[package]]
 name = "ck-chunk"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -433,7 +433,7 @@ dependencies = [
 
 [[package]]
 name = "ck-core"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -447,7 +447,7 @@ dependencies = [
 
 [[package]]
 name = "ck-embed"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "ck-engine"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ck-ann",
@@ -480,7 +480,7 @@ dependencies = [
 
 [[package]]
 name = "ck-index"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -502,7 +502,7 @@ dependencies = [
 
 [[package]]
 name = "ck-models"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -512,7 +512,7 @@ dependencies = [
 
 [[package]]
 name = "ck-search"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "anyhow",
  "ck-ann",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Mike Renwick"]
 license = "MIT OR Apache-2.0"

--- a/PHASE1_PRD.md
+++ b/PHASE1_PRD.md
@@ -1,0 +1,231 @@
+# Phase 1 PRD: Agent-Ready Code Navigation
+
+## Executive Summary
+
+Transform `ck` into the definitive AI agent toolkit for code navigation by adding structured output, improved filtering, symbol indexing, and edit anchors. Focus: agent-ready primitives that maintain grep-like composability.
+
+## Feature 1: JSONL Output (Agent-Friendly Structured Data)
+
+### Problem Statement
+AI agents struggle with grep's unstructured text output, requiring fragile regex parsing. Agents need reliable, structured data for automation.
+
+### Solution
+Add `--jsonl` flag for machine-readable output format.
+
+### Acceptance Criteria
+
+**CLI Interface:**
+```bash
+# Basic JSONL output
+ck "function.*auth" --jsonl
+
+# JSONL with options
+ck --sem "authentication logic" --jsonl --no-snippet --context 3 --topk 10
+```
+
+**Output Format:**
+```jsonl
+{"path":"src/auth.ts","span":{"line_start":42,"line_end":58,"byte_start":1203,"byte_end":1456},"language":"typescript","snippet":"function authenticate(user) {...}","score":0.89,"chunk_hash":"abc123","index_epoch":1699123456}
+{"path":"lib/user.py","span":{"line_start":15,"line_end":23,"byte_start":456,"byte_end":789},"language":"python","snippet":"def login(username):...","score":0.76,"chunk_hash":"def456","index_epoch":1699123456}
+```
+
+**Required Fields:**
+- `path`: Relative file path
+- `span`: Object with `line_start`, `line_end`, `byte_start`, `byte_end`
+- `language`: Detected programming language
+- `snippet`: Code snippet (optional with `--no-snippet`)
+- `score`: Relevance score (0.0-1.0, null for regex)
+- `chunk_hash`: Unique hash for this code chunk
+- `index_epoch`: Timestamp when index was created
+
+**Flags:**
+- `--jsonl`: Enable JSONL output mode
+- `--no-snippet`: Exclude code snippets (just metadata)
+- `--context N`: Include N lines before/after match
+- `--topk N`: Limit results to top N matches
+- `--threshold S`: Minimum similarity score (0.0-1.0)
+- `--timeout MS`: Query timeout in milliseconds
+
+**Implementation:**
+- **Module**: `ck-cli/src/main.rs` - Add JSONL output option
+- **Module**: `ck-cli/src/output.rs` - Create new output formatter
+- **Module**: `ck-core/src/lib.rs` - Extend SearchResult struct
+- **Tests**: Comprehensive JSONL format validation
+
+---
+
+## Feature 2: Improved Filtering (Directory and Language Constraints)
+
+### Problem Statement
+Current filtering requires complex regex patterns. Agents need simple, predictable constraints for scoping searches.
+
+### Solution
+Add intuitive directory and language filtering flags.
+
+### Acceptance Criteria
+
+**CLI Interface:**
+```bash
+# Directory filtering
+ck "auth" --in src,lib --not-in tests,node_modules
+
+# Language filtering  
+ck "class.*User" --lang js,ts,py
+
+# Combined filtering
+ck --sem "database connection" --in src --lang py,js --jsonl
+```
+
+**Flags:**
+- `--in <dir[,dir...]>`: Include only specified directories
+- `--not-in <dir[,dir...]>`: Exclude specified directories  
+- `--lang <ext[,ext...]>`: Filter by file extensions/languages
+
+**Supported Languages:**
+- `js,ts,jsx,tsx` (JavaScript/TypeScript)
+- `py` (Python)
+- `rs` (Rust)
+- `go` (Go)
+- `rb` (Ruby)
+- `hs` (Haskell)
+- `java` (Java)
+- `cpp,cc,cxx` (C++)
+
+**Implementation:**
+- **Module**: `ck-cli/src/main.rs` - Add filtering CLI args
+- **Module**: `ck-index/src/lib.rs` - Extend filtering logic in existing override builder
+- **Module**: `ck-core/src/lib.rs` - Add language detection utilities
+- **Tests**: Directory and language filtering validation
+
+---
+
+## Feature 3: Symbol Index (Definitions/References/Exports)
+
+### Problem Statement
+Finding where symbols are defined, used, or exported requires manual scanning. Agents need fast symbol navigation.
+
+### Solution
+Add `ck sym` subcommand for symbol-based queries using ctags-grade heuristics.
+
+### Acceptance Criteria
+
+**CLI Interface:**
+```bash
+# Find symbol definitions
+ck sym --def authenticate
+
+# Find symbol references
+ck sym --refs UserController
+
+# Pattern-based symbol search
+ck sym --like ".*Handler"
+
+# List all exports
+ck sym --exports --lang ts,js
+```
+
+**Output Format (JSONL):**
+```jsonl
+{"symbol":"authenticate","kind":"function","role":"definition","path":"src/auth.ts","line":42,"byte":1203,"language":"typescript"}
+{"symbol":"authenticate","kind":"function","role":"reference","path":"src/login.ts","line":15,"byte":456,"language":"typescript"}
+{"symbol":"UserModel","kind":"class","role":"export","path":"src/models/user.ts","line":1,"byte":0,"language":"typescript"}
+```
+
+**Symbol Kinds:**
+- `function`, `class`, `interface`, `type`, `const`, `var`, `import`, `export`
+
+**Symbol Roles:**
+- `definition`: Where symbol is defined
+- `reference`: Where symbol is used
+- `export`: Where symbol is exported
+
+**Implementation:**
+- **Module**: `ck-cli/src/sym.rs` - New subcommand implementation
+- **Module**: `ck-symbols/` - New crate for symbol extraction
+- **Module**: `ck-symbols/src/extractors/` - Language-specific symbol extractors
+- **Dependencies**: Leverage existing tree-sitter parsers
+- **Tests**: Symbol extraction accuracy per language
+
+---
+
+## Feature 4: Anchors for Patch Safety (Edit Context Verification)
+
+### Problem Statement
+Agents making code edits need stable reference points to verify context hasn't changed before applying modifications.
+
+### Solution
+Add `ck anchors` subcommand to generate stable edit anchors around code spans.
+
+### Acceptance Criteria
+
+**CLI Interface:**
+```bash
+# Generate anchors for specific line range
+ck anchors src/auth.ts --line-start 42 --line-end 58 --json
+
+# Generate anchors with context
+ck anchors src/auth.ts --line-start 42 --line-end 58 --context 3 --json
+```
+
+**Output Format:**
+```json
+{
+  "file": "src/auth.ts",
+  "target_span": {"line_start": 42, "line_end": 58, "byte_start": 1203, "byte_end": 1456},
+  "pre_anchor": "export class UserAuth {",
+  "post_anchor": "  public logout(): void {",
+  "chunk_hash": "abc123def456",
+  "context_lines": 3,
+  "generated_at": 1699123456
+}
+```
+
+**Flags:**
+- `--line-start N`: Start line of target span
+- `--line-end N`: End line of target span  
+- `--context N`: Lines of context for anchor generation (default: 2)
+- `--json`: Output as JSON (default for anchors)
+
+**Anchor Selection Algorithm:**
+1. Find stable lines before/after target (class/function declarations, comments)
+2. Prefer unique, unlikely-to-change identifiers
+3. Include enough context to uniquely identify location
+4. Generate content hash for change detection
+
+**Implementation:**
+- **Module**: `ck-cli/src/anchors.rs` - New subcommand
+- **Module**: `ck-core/src/anchors.rs` - Anchor generation logic
+- **Tests**: Anchor stability and uniqueness validation
+
+---
+
+## Implementation Approach
+
+### Feature Priority
+1. **JSONL Output** - Foundation for all agent interactions
+2. **Enhanced Filtering** - Builds on existing systems  
+3. **Symbol Index** - Leverages tree-sitter infrastructure
+4. **Edit Anchors** - Enables safe programmatic modifications
+
+### Development Strategy
+- Iterative implementation with immediate testing
+- Each feature provides standalone value
+- Maintain backward compatibility
+- Preserve grep-like performance characteristics
+
+### Quality Gates
+- **Unit tests**: Each feature in isolation
+- **Integration tests**: Cross-feature compatibility  
+- **Agent simulation**: Real workflow validation
+- **Performance**: Sub-500ms query responses
+
+---
+
+## Future Considerations (Phase 2+)
+
+This Phase 1 foundation enables:
+- **Import/Call graphs**: Building on symbol index
+- **Configurable context**: Extending anchor system  
+- **ck-toolbelt**: Higher-order repo analysis tools
+
+Each Phase 1 feature is designed to be independently valuable while creating building blocks for advanced agent workflows.

--- a/PRD.txt
+++ b/PRD.txt
@@ -289,7 +289,7 @@ ck/
 
 ---
 
-## Current Implementation Status (v0.4.0)
+## Current Implementation Status (v0.4.1)
 
 ### ✅ **Production Ready Features**
 - **Complete grep replacement**: All major flags supported with identical behavior

--- a/ck-ann/Cargo.toml
+++ b/ck-ann/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["search", "ann", "vector"]
 categories = ["algorithms"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-chunk/Cargo.toml
+++ b/ck-chunk/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["parsing", "chunking", "tree-sitter"]
 categories = ["parsing"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-cli/Cargo.toml
+++ b/ck-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ck-search"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 authors = ["Mike Renwick"]
 license = "MIT OR Apache-2.0"
@@ -17,13 +17,13 @@ name = "ck"
 path = "src/main.rs"
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
-ck-index = { version = "0.4.0", path = "../ck-index" }
-ck-engine = { version = "0.4.0", path = "../ck-engine" }
-ck-chunk = { version = "0.4.0", path = "../ck-chunk" }
-ck-embed = { version = "0.4.0", path = "../ck-embed" }
-ck-ann = { version = "0.4.0", path = "../ck-ann" }
-ck-models = { version = "0.4.0", path = "../ck-models" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
+ck-index = { version = "0.4.1", path = "../ck-index" }
+ck-engine = { version = "0.4.1", path = "../ck-engine" }
+ck-chunk = { version = "0.4.1", path = "../ck-chunk" }
+ck-embed = { version = "0.4.1", path = "../ck-embed" }
+ck-ann = { version = "0.4.1", path = "../ck-ann" }
+ck-models = { version = "0.4.1", path = "../ck-models" }
 
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/ck-embed/Cargo.toml
+++ b/ck-embed/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["embedding", "nlp", "semantic"]
 categories = ["science"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-engine/Cargo.toml
+++ b/ck-engine/Cargo.toml
@@ -11,11 +11,11 @@ keywords = ["search", "engine", "semantic"]
 categories = ["algorithms"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
-ck-index = { version = "0.4.0", path = "../ck-index" }
-ck-embed = { version = "0.4.0", path = "../ck-embed" }
-ck-ann = { version = "0.4.0", path = "../ck-ann" }
-ck-chunk = { version = "0.4.0", path = "../ck-chunk" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
+ck-index = { version = "0.4.1", path = "../ck-index" }
+ck-embed = { version = "0.4.1", path = "../ck-embed" }
+ck-ann = { version = "0.4.1", path = "../ck-ann" }
+ck-chunk = { version = "0.4.1", path = "../ck-chunk" }
 serde_json = { workspace = true }
 
 anyhow = { workspace = true }

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -203,6 +203,8 @@ fn search_file(
                 preview,
                 lang: ck_core::Language::from_path(file_path),
                 symbol: None,
+                chunk_hash: None,
+                index_epoch: None,
             });
         }
 
@@ -298,6 +300,8 @@ async fn lexical_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
                 preview,
                 lang: ck_core::Language::from_path(&PathBuf::from(path_text)),
                 symbol: None,
+                chunk_hash: None,
+                index_epoch: None,
             },
         ));
     }
@@ -433,6 +437,8 @@ async fn build_tantivy_index(options: &SearchOptions) -> Result<Vec<SearchResult
                 preview,
                 lang: ck_core::Language::from_path(&PathBuf::from(path_text)),
                 symbol: None,
+                chunk_hash: None,
+                index_epoch: None,
             },
         ));
     }
@@ -582,6 +588,8 @@ async fn semantic_search_with_progress(
                 preview,
                 lang: ck_core::Language::from_path(file_path),
                 symbol: None,
+                chunk_hash: None,
+                index_epoch: None,
             });
         }
     }
@@ -775,6 +783,8 @@ async fn build_semantic_index_with_progress(
                 preview,
                 lang: ck_core::Language::from_path(file_path),
                 symbol: None,
+                chunk_hash: None,
+                index_epoch: None,
             });
         }
     }

--- a/ck-engine/src/semantic_v3.rs
+++ b/ck-engine/src/semantic_v3.rs
@@ -157,6 +157,8 @@ pub async fn semantic_search_v3_with_progress(
             preview: content,
             lang: ck_core::Language::from_path(file_path),
             symbol: None,
+            chunk_hash: None,
+            index_epoch: None,
         });
     }
 

--- a/ck-index/Cargo.toml
+++ b/ck-index/Cargo.toml
@@ -11,9 +11,9 @@ keywords = ["indexing", "search", "storage"]
 categories = ["database-implementations"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
-ck-chunk = { version = "0.4.0", path = "../ck-chunk" }
-ck-embed = { version = "0.4.0", path = "../ck-embed" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
+ck-chunk = { version = "0.4.1", path = "../ck-chunk" }
+ck-embed = { version = "0.4.1", path = "../ck-embed" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-models/Cargo.toml
+++ b/ck-models/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["models", "config", "registry"]
 categories = ["config"]
 
 [dependencies]
-ck-core = { version = "0.4.0", path = "../ck-core" }
+ck-core = { version = "0.4.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Implements Phase 1 of agent-ready code navigation with streaming-friendly JSONL output format.

### Added
- **JSONL output format**: Stream-friendly `--jsonl` flag for AI agents
- **No-snippet mode**: `--no-snippet` flag for metadata-only output
- **Agent documentation**: Comprehensive README section explaining JSONL benefits
- **Agent examples**: Python code showing stream processing patterns

### Technical
- Extended SearchResult struct with chunk_hash and index_epoch fields
- Added JsonlSearchResult struct with conversion methods
- Comprehensive integration tests (4 new test cases)
- Updated help text with dedicated JSONL section for agents
- UTF-8 warning suppression for .git binary files to reduce noise

### Why JSONL for AI Agents?
- Streaming friendly: Process results as they arrive
- Memory efficient: Parse one result at a time
- Error resilient: Malformed lines don't break entire response
- Standard format: Used by OpenAI, Anthropic, and ML pipelines

🤖 Generated with [Claude Code](https://claude.ai/code)