### PR TITLE
Fix: Make crates.io publishing reliable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -218,22 +218,102 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: |
-          # Publish workspace crates in dependency order
-          cargo publish -p ck-core --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-models --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-chunk --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-embed --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-ann --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-index --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-engine --token $CARGO_REGISTRY_TOKEN || true
-          sleep 10
-          cargo publish -p ck-search --token $CARGO_REGISTRY_TOKEN || true
+          # Function to publish with retries and verification
+          publish_crate() {
+            local package=$1
+            local max_attempts=5
+            local wait_time=30
+
+            echo "Publishing $package..."
+
+            for attempt in $(seq 1 $max_attempts); do
+              echo "Attempt $attempt/$max_attempts for $package"
+
+              # Try to publish
+              if cargo publish -p "$package" --token "$CARGO_REGISTRY_TOKEN" 2>&1 | tee /tmp/publish_output.txt; then
+                echo "Successfully published $package"
+                return 0
+              fi
+
+              # Check if it's already published
+              if grep -q "already uploaded" /tmp/publish_output.txt || \
+                 grep -q "already exists" /tmp/publish_output.txt; then
+                echo "$package is already published, continuing..."
+                return 0
+              fi
+
+              # If it failed due to missing dependency, wait longer
+              if grep -q "failed to select a version" /tmp/publish_output.txt; then
+                echo "Dependency not yet available, waiting ${wait_time}s before retry..."
+                sleep $wait_time
+                # Increase wait time for subsequent attempts
+                wait_time=$((wait_time * 2))
+              else
+                # For other errors, fail immediately
+                echo "Publishing $package failed with unexpected error"
+                cat /tmp/publish_output.txt
+                return 1
+              fi
+            done
+
+            echo "Failed to publish $package after $max_attempts attempts"
+            return 1
+          }
+
+          # Function to verify crate is available on crates.io
+          verify_crate() {
+            local package=$1
+            local version=$2
+            local max_attempts=10
+
+            echo "Verifying $package v$version is available on crates.io..."
+
+            for attempt in $(seq 1 $max_attempts); do
+              # Update the index and check if package is available
+              cargo search "$package" --limit 1 | grep -q "^$package = \"$version\""
+              if [ $? -eq 0 ]; then
+                echo "$package v$version verified on crates.io"
+                return 0
+              fi
+
+              echo "Waiting for $package v$version to be available (attempt $attempt/$max_attempts)..."
+              sleep 30
+            done
+
+            echo "Failed to verify $package v$version on crates.io"
+            return 1
+          }
+
+          # Get version from workspace Cargo.toml
+          VERSION=$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          echo "Publishing version $VERSION"
+
+          # Publish in dependency order with verification
+          CRATES=(
+            "ck-core"
+            "ck-models"
+            "ck-embed"
+            "ck-chunk"
+            "ck-ann"
+            "ck-index"
+            "ck-engine"
+            "ck-search"
+          )
+
+          for crate in "${CRATES[@]}"; do
+            if ! publish_crate "$crate"; then
+              echo "Failed to publish $crate, aborting..."
+              exit 1
+            fi
+
+            # Verify the crate is available before proceeding to dependents
+            if ! verify_crate "$crate" "$VERSION"; then
+              echo "Failed to verify $crate, aborting..."
+              exit 1
+            fi
+          done
+
+          echo "All crates published successfully!"
 
   finalize-release:
     name: Finalize GitHub Release


### PR DESCRIPTION
## Problem
v0.4.5 only partially published to crates.io (4/8 crates) due to race conditions.

## Solution
- Add retry logic with exponential backoff
- Verify each crate is indexed before publishing dependents
- Remove `|| true` to catch failures properly
- Fix dependency order

## Next Steps
After merging, tag v0.4.5 again to trigger full republish.

Fixes #53

🤖 Generated with [Claude Code](https://claude.ai/code)