### PR TITLE
Fix Windows test failures due to model access conflicts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "owo-colors",
  "regex",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tracing",
@@ -862,6 +863,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04d2cd9c18b9f454ed67da600630b021a8a80bf33f8c95896ab33aaf1c26b728"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1217,12 +1231,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1230,6 +1260,17 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -1266,6 +1307,7 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1358,6 +1400,12 @@ dependencies = [
  "cfg-if",
  "crunchy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -1706,7 +1754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "206a8042aec68fa4a62e8d3f7aa4ceb508177d9324faf261e1959e495b7a1921"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1946,7 +1994,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3191,6 +3239,31 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/ck-cli/Cargo.toml
+++ b/ck-cli/Cargo.toml
@@ -44,3 +44,4 @@ vendored-openssl = ["openssl?/vendored"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
+serial_test = "3.2"

--- a/ck-cli/Cargo.toml
+++ b/ck-cli/Cargo.toml
@@ -44,4 +44,4 @@ vendored-openssl = ["openssl?/vendored"]
 
 [dev-dependencies]
 tempfile = { workspace = true }
-serial_test = "3.2"
+serial_test = "2.0"

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -1,9 +1,9 @@
+#[cfg(test)]
+use serial_test::serial;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
-#[cfg(test)]
-use serial_test::serial;
 
 fn ck_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ck"))

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -2,6 +2,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use tempfile::TempDir;
+#[cfg(test)]
+use serial_test::serial;
 
 fn ck_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ck"))
@@ -103,6 +105,7 @@ fn test_json_output() {
 }
 
 #[test]
+#[serial]
 fn test_index_command() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.txt"), "indexable content").unwrap();
@@ -139,6 +142,7 @@ fn read_manifest_updated(dir: &Path) -> u64 {
 }
 
 #[test]
+#[serial]
 fn test_switch_model_skips_when_same_model() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.rs"), "fn main() {}").unwrap();
@@ -170,6 +174,7 @@ fn test_switch_model_skips_when_same_model() {
 }
 
 #[test]
+#[serial]
 fn test_switch_model_force_rebuild() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(
@@ -208,6 +213,7 @@ fn test_switch_model_force_rebuild() {
 }
 
 #[test]
+#[serial]
 fn test_semantic_search() {
     let temp_dir = TempDir::new().unwrap();
 
@@ -261,6 +267,7 @@ fn test_semantic_search() {
 }
 
 #[test]
+#[serial]
 fn test_lexical_search() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(
@@ -297,6 +304,7 @@ fn test_lexical_search() {
 }
 
 #[test]
+#[serial]
 fn test_hybrid_search() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(
@@ -396,6 +404,7 @@ fn test_line_numbers() {
 }
 
 #[test]
+#[serial]
 fn test_clean_command() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.txt"), "test content").unwrap();
@@ -707,6 +716,7 @@ fn test_jsonl_with_different_languages() {
 }
 
 #[test]
+#[serial]
 fn test_add_single_file_to_index() {
     let temp_dir = TempDir::new().unwrap();
 
@@ -767,6 +777,7 @@ fn test_add_single_file_to_index() {
 }
 
 #[test]
+#[serial]
 fn test_add_file_with_relative_path() {
     let temp_dir = TempDir::new().unwrap();
 


### PR DESCRIPTION
## Problem

Windows CI tests are failing with 'Access is denied' errors when trying to access ONNX model files during embedding operations.

## Root Cause

Multiple test processes running in parallel on Windows are trying to download/access the same fastembed model files simultaneously, causing file locking conflicts.

## Solution

Serialize tests that involve indexing operations using the `serial_test` crate. This ensures only one test at a time accesses the model cache directory on Windows.

## Changes

- Add `serial_test` dependency for test coordination
- Mark all indexing-related tests with `#[serial]` attribute
- Tests affected:
  - `test_index_command`
  - `test_switch_model_skips_when_same_model`
  - `test_switch_model_force_rebuild`
  - `test_semantic_search`
  - `test_lexical_search`
  - `test_hybrid_search`
  - `test_clean_command`
  - `test_add_single_file_to_index`
  - `test_add_file_with_relative_path`

## Impact

- Tests will run slightly slower on Windows due to serialization
- No impact on Linux/macOS where file locking works differently
- Fixes CI reliability on Windows runners

## Testing

The serialized tests should now pass on Windows without 'Access is denied' errors.