### PR TITLE
chore: bump version to 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,7 +488,7 @@ dependencies = [
 
 [[package]]
 name = "ck-ann"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -499,7 +499,7 @@ dependencies = [
 
 [[package]]
 name = "ck-chunk"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -520,7 +520,7 @@ dependencies = [
 
 [[package]]
 name = "ck-core"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -534,7 +534,7 @@ dependencies = [
 
 [[package]]
 name = "ck-embed"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -545,7 +545,7 @@ dependencies = [
 
 [[package]]
 name = "ck-engine"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ck-ann",
@@ -568,7 +568,7 @@ dependencies = [
 
 [[package]]
 name = "ck-index"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "bincode",
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "ck-models"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "ck-core",
@@ -602,7 +602,7 @@ dependencies = [
 
 [[package]]
 name = "ck-search"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Mike Renwick"]
 license = "MIT OR Apache-2.0"

--- a/ck-ann/Cargo.toml
+++ b/ck-ann/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["search", "ann", "vector"]
 categories = ["algorithms"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-chunk/Cargo.toml
+++ b/ck-chunk/Cargo.toml
@@ -11,8 +11,8 @@ keywords = ["parsing", "chunking", "tree-sitter"]
 categories = ["parsing"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
-ck-embed = { version = "0.5.0", path = "../ck-embed" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
+ck-embed = { version = "0.5.1", path = "../ck-embed" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-cli/Cargo.toml
+++ b/ck-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ck-search"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2024"
 authors = ["Mike Renwick"]
 license = "MIT OR Apache-2.0"
@@ -21,13 +21,13 @@ name = "ck_search"
 path = "src/lib.rs"
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
-ck-index = { version = "0.5.0", path = "../ck-index" }
-ck-engine = { version = "0.5.0", path = "../ck-engine" }
-ck-chunk = { version = "0.5.0", path = "../ck-chunk" }
-ck-embed = { version = "0.5.0", path = "../ck-embed" }
-ck-ann = { version = "0.5.0", path = "../ck-ann" }
-ck-models = { version = "0.5.0", path = "../ck-models" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
+ck-index = { version = "0.5.1", path = "../ck-index" }
+ck-engine = { version = "0.5.1", path = "../ck-engine" }
+ck-chunk = { version = "0.5.1", path = "../ck-chunk" }
+ck-embed = { version = "0.5.1", path = "../ck-embed" }
+ck-ann = { version = "0.5.1", path = "../ck-ann" }
+ck-models = { version = "0.5.1", path = "../ck-models" }
 
 anyhow = { workspace = true }
 clap = { workspace = true }

--- a/ck-embed/Cargo.toml
+++ b/ck-embed/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["embedding", "nlp", "semantic"]
 categories = ["science"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-engine/Cargo.toml
+++ b/ck-engine/Cargo.toml
@@ -11,12 +11,12 @@ keywords = ["search", "engine", "semantic"]
 categories = ["algorithms"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
-ck-index = { version = "0.5.0", path = "../ck-index" }
-ck-embed = { version = "0.5.0", path = "../ck-embed" }
-ck-ann = { version = "0.5.0", path = "../ck-ann" }
-ck-chunk = { version = "0.5.0", path = "../ck-chunk" }
-ck-models = { version = "0.5.0", path = "../ck-models" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
+ck-index = { version = "0.5.1", path = "../ck-index" }
+ck-embed = { version = "0.5.1", path = "../ck-embed" }
+ck-ann = { version = "0.5.1", path = "../ck-ann" }
+ck-chunk = { version = "0.5.1", path = "../ck-chunk" }
+ck-models = { version = "0.5.1", path = "../ck-models" }
 serde_json = { workspace = true }
 
 anyhow = { workspace = true }

--- a/ck-index/Cargo.toml
+++ b/ck-index/Cargo.toml
@@ -11,10 +11,10 @@ keywords = ["indexing", "search", "storage"]
 categories = ["database-implementations"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
-ck-chunk = { version = "0.5.0", path = "../ck-chunk" }
-ck-embed = { version = "0.5.0", path = "../ck-embed" }
-ck-models = { version = "0.5.0", path = "../ck-models" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
+ck-chunk = { version = "0.5.1", path = "../ck-chunk" }
+ck-embed = { version = "0.5.1", path = "../ck-embed" }
+ck-models = { version = "0.5.1", path = "../ck-models" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }

--- a/ck-models/Cargo.toml
+++ b/ck-models/Cargo.toml
@@ -11,7 +11,7 @@ keywords = ["models", "config", "registry"]
 categories = ["config"]
 
 [dependencies]
-ck-core = { version = "0.5.0", path = "../ck-core" }
+ck-core = { version = "0.5.1", path = "../ck-core" }
 
 anyhow = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary

Patch version bump to 0.5.1 following critical bug fixes merged in #60.

## Changes

- **Workspace version**: `0.5.0` → `0.5.1`
- **All crate versions**: Updated to `0.5.1` across the workspace
- **Internal dependencies**: Updated all `ck-*` crate references to `0.5.1`

## Rationale

This patch release includes critical fixes for:
- Divide-by-zero panics in chunking 
- Line ending byte offset issues in regex search
- Off-by-one errors in strided chunk calculations

## Test plan

- [x] Workspace builds successfully with new versions
- [ ] CI/CD pipeline passes (waiting for automated checks)
- [ ] All tests continue to pass in CI environment
- [ ] Cross-platform compatibility verified

**Note**: This time I will wait for CI/CD to complete before merging! 🤖

🤖 Generated with [Claude Code](https://claude.ai/code)