### PR TITLE
Fix CLI output formatting

### DIFF
--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -1728,7 +1728,7 @@ async fn run_search(
             };
 
             let file_text = if options.show_filenames {
-                format!("{}:", style(result.file.display()).cyan().bold())
+                format!("{}:\n", style(result.file.display()).cyan().bold())
             } else {
                 String::new()
             };

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -59,7 +59,7 @@ fn test_case_insensitive_search() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let line_count = stdout.lines().count();
-    assert_eq!(line_count, 3); // Should match all three lines
+    assert_eq!(line_count, 6); // Should match all three lines (filename + content for each)
 }
 
 #[test]
@@ -81,7 +81,7 @@ fn test_recursive_search() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let line_count = stdout.lines().count();
-    assert_eq!(line_count, 2); // Should find matches in both files
+    assert_eq!(line_count, 4); // Should find matches in both files (filename + content for each)
 }
 
 #[test]
@@ -379,7 +379,7 @@ fn test_topk_limit() {
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     let line_count = stdout.trim().lines().count();
-    assert!(line_count <= 5);
+    assert!(line_count <= 10); // Up to 5 results, each with filename + content line
 }
 
 #[test]
@@ -400,7 +400,7 @@ fn test_line_numbers() {
     let stdout = String::from_utf8(output.stdout).unwrap();
 
     // Should include line number (line 2)
-    assert!(stdout.contains(":2:"));
+    assert!(stdout.contains("2:matched line"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Add line break after filename in CLI output for improved readability
- Update integration tests to match new output format

Fixes #70

## Test plan
- [x] All tests pass (`cargo test`)
- [x] Linting passes (`cargo clippy`)
- [x] Code formatted (`cargo fmt`)
- [x] Manual testing with multi-file searches

🤖 Generated with [Claude Code](https://claude.com/claude-code)