### PR TITLE
Fix VSCode extension robustness issues

### DIFF
--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -312,6 +312,9 @@ struct Cli {
     #[arg(long = "status-verbose", help = "Show detailed index statistics")]
     status_verbose: bool,
 
+    #[arg(long = "status-json", help = "Output index status as JSON")]
+    status_json: bool,
+
     #[arg(
         long = "inspect",
         help = "Show detailed metadata for a specific file (chunks, embeddings, tree-sitter parsing info)"
@@ -1136,8 +1139,8 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
         return Ok(());
     }
 
-    if cli.status || cli.status_verbose {
-        // Handle --status and --status-verbose flags
+    if cli.status || cli.status_verbose || cli.status_json {
+        // Handle --status, --status-verbose, and --status-json flags
         let status_path = cli
             .files
             .first()
@@ -1145,12 +1148,64 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
             .unwrap_or_else(|| PathBuf::from("."));
         let verbose = cli.status_verbose;
 
-        status.section_header("Index Status");
-        let check_spinner = status.create_spinner("Reading index...");
-        let stats = ck_index::get_index_stats(&status_path)?;
-        status.finish_progress(check_spinner, "Status retrieved");
+        let stats = if cli.status_json {
+            // For JSON output, skip spinner and human-readable messages
+            ck_index::get_index_stats(&status_path)?
+        } else {
+            status.section_header("Index Status");
+            let check_spinner = status.create_spinner("Reading index...");
+            let stats = ck_index::get_index_stats(&status_path)?;
+            status.finish_progress(check_spinner, "Status retrieved");
+            stats
+        };
 
-        if stats.total_files == 0 {
+        if cli.status_json {
+            // Output JSON format
+            let mut json_output = serde_json::json!({
+                "path": status_path.to_string_lossy(),
+                "index_exists": stats.total_files > 0,
+                "total_files": stats.total_files,
+                "total_chunks": stats.total_chunks,
+                "embedded_chunks": stats.embedded_chunks,
+                "total_size_bytes": stats.total_size_bytes,
+                "index_size_bytes": stats.index_size_bytes,
+                "index_created": stats.index_created,
+                "index_updated": stats.index_updated,
+            });
+
+            // Add model information if available
+            let manifest_path = status_path.join(".ck").join("manifest.json");
+            if let Ok(data) = std::fs::read(&manifest_path)
+                && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
+                && let Some(model_name) = manifest.embedding_model
+            {
+                let registry = ck_models::ModelRegistry::default();
+                let alias = registry
+                    .models
+                    .iter()
+                    .find(|(_, config)| config.name == model_name)
+                    .map(|(alias, _)| alias.clone())
+                    .unwrap_or_else(|| model_name.clone());
+                let dims = manifest
+                    .embedding_dimensions
+                    .or_else(|| {
+                        registry
+                            .models
+                            .iter()
+                            .find(|(_, config)| config.name == model_name)
+                            .map(|(_, config)| config.dimensions)
+                    })
+                    .unwrap_or(0);
+
+                json_output["model"] = serde_json::json!({
+                    "name": model_name,
+                    "alias": alias,
+                    "dimensions": dims,
+                });
+            }
+
+            println!("{}", serde_json::to_string_pretty(&json_output)?);
+        } else if stats.total_files == 0 {
             status.warn(&format!("No index found at {}", status_path.display()));
             status.info("Run 'ck --index .' to create an index");
         } else {

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -1690,7 +1690,40 @@ impl CkMcpServer {
             } else if let Ok(index_stats) = ck_index::get_index_stats(&path_buf) {
                 index_info["total_files"] = json!(index_stats.total_files);
                 index_info["total_chunks"] = json!(index_stats.total_chunks);
+                index_info["embedded_chunks"] = json!(index_stats.embedded_chunks);
+                index_info["total_size_bytes"] = json!(index_stats.total_size_bytes);
                 index_info["cache_hit"] = json!(false);
+
+                // Add model information if available
+                let manifest_path = path_buf.join(".ck").join("manifest.json");
+                if let Ok(data) = std::fs::read(&manifest_path)
+                    && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
+                    && let Some(model_name) = manifest.embedding_model
+                {
+                    let registry = ck_models::ModelRegistry::default();
+                    let alias = registry
+                        .models
+                        .iter()
+                        .find(|(_, config)| config.name == model_name)
+                        .map(|(alias, _)| alias.clone())
+                        .unwrap_or_else(|| model_name.clone());
+                    let dims = manifest
+                        .embedding_dimensions
+                        .or_else(|| {
+                            registry
+                                .models
+                                .iter()
+                                .find(|(_, config)| config.name == model_name)
+                                .map(|(_, config)| config.dimensions)
+                        })
+                        .unwrap_or(0);
+
+                    index_info["model"] = json!({
+                        "name": model_name,
+                        "alias": alias,
+                        "dimensions": dims,
+                    });
+                }
 
                 // Update cache with fresh stats
                 let cache_stats = crate::mcp::cache::IndexStats {

--- a/ck-vscode/src/mcpAdapter.ts
+++ b/ck-vscode/src/mcpAdapter.ts
@@ -91,11 +91,18 @@ export class CkMcpAdapter {
       path: status.path ?? pathToCheck,
       totalFiles: status.total_files,
       totalChunks: status.total_chunks,
+      embeddedChunks: status.embedded_chunks,
+      totalSizeBytes: status.total_size_bytes,
       lastModified: status.last_modified,
       indexPath: status.index_path,
       indexSizeBytes: status.index_size_bytes,
       estimatedFileCount: status.estimated_file_count,
-      cacheHit: status.cache_hit
+      cacheHit: status.cache_hit,
+      model: status.model ? {
+        name: status.model.name,
+        alias: status.model.alias,
+        dimensions: status.model.dimensions
+      } : undefined
     };
   }
 

--- a/ck-vscode/src/types.ts
+++ b/ck-vscode/src/types.ts
@@ -44,11 +44,18 @@ export interface IndexStatus {
   path: string;
   totalFiles?: number;
   totalChunks?: number;
+  embeddedChunks?: number;
   lastModified?: number;
   indexPath?: string;
   indexSizeBytes?: number;
+  totalSizeBytes?: number;
   estimatedFileCount?: number;
   cacheHit?: boolean;
+  model?: {
+    name: string;
+    alias: string;
+    dimensions: number;
+  };
 }
 
 export interface SearchResponse {


### PR DESCRIPTION
- Add --status-json flag to CLI for structured status output, eliminating brittle regex parsing of human-readable text. Both CLI and MCP adapters now return consistent structured data including embedded_chunks, total_size_bytes, and model metadata.

- Add -- separator before query in CLI adapter argument building to prevent dash-prefixed queries (e.g., "-foo") from being incorrectly parsed as command-line flags.

- Replace hardcoded 66-line .ckignore fallback template with minimal error-state template. Extension now always fetches default patterns from ck backend via --print-default-ckignore (CLI) or default_ckignore tool (MCP), preventing drift when ck-core updates its template. Fallback only used when backend fetch fails, with clear user warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)