### PR TITLE
fix: Add hierarchical .ckignore support to fix subdirectory search and indexing performance

### DIFF
--- a/ck-cli/src/mcp/context.rs
+++ b/ck-cli/src/mcp/context.rs
@@ -53,6 +53,7 @@ impl McpContext {
             exclude_patterns: get_default_exclude_patterns(),
             include_patterns: Vec::new(),
             respect_gitignore: true,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,

--- a/ck-cli/src/mcp/session.rs
+++ b/ck-cli/src/mcp/session.rs
@@ -463,6 +463,7 @@ mod tests {
             exclude_patterns: vec![],
             include_patterns: Vec::new(),
             respect_gitignore: true,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -77,25 +77,15 @@ mod tests {
 }
 
 fn resolve_exclude_patterns(
-    base_path: &Path,
     explicit: Option<Vec<String>>,
     use_default_excludes: Option<bool>,
 ) -> Vec<String> {
-    let mut patterns = Vec::new();
-
-    if let Ok(ckignore_patterns) = ck_core::read_ckignore_patterns(base_path) {
-        patterns.extend(ckignore_patterns);
-    }
-
-    if let Some(mut provided) = explicit {
-        patterns.append(&mut provided);
-    }
-
-    if use_default_excludes.unwrap_or(true) {
-        patterns.extend(get_default_exclude_patterns());
-    }
-
-    patterns
+    // Note: .ckignore files are now handled hierarchically by WalkBuilder
+    // This function only combines explicit excludes with defaults
+    ck_core::build_exclude_patterns(
+        &explicit.unwrap_or_default(),
+        use_default_excludes.unwrap_or(true),
+    )
 }
 
 fn resolve_include_patterns(
@@ -1010,7 +1000,6 @@ impl CkMcpServer {
         let respect_gitignore = request.respect_gitignore.unwrap_or(true);
         let use_default_excludes = request.use_default_excludes.unwrap_or(true);
         let exclude_patterns = resolve_exclude_patterns(
-            &search_root,
             request.exclude_patterns.clone(),
             Some(use_default_excludes),
         );
@@ -1099,6 +1088,7 @@ impl CkMcpServer {
             exclude_patterns,
             include_patterns,
             respect_gitignore,
+            use_ckignore: true,
             full_section: false,
             rerank: request.rerank.unwrap_or(false),
             rerank_model: request.rerank_model.clone(),
@@ -1251,7 +1241,6 @@ impl CkMcpServer {
         let respect_gitignore = request.respect_gitignore.unwrap_or(true);
         let use_default_excludes = request.use_default_excludes.unwrap_or(true);
         let exclude_patterns = resolve_exclude_patterns(
-            &search_root,
             request.exclude_patterns.clone(),
             Some(use_default_excludes),
         );
@@ -1308,6 +1297,7 @@ impl CkMcpServer {
             exclude_patterns,
             include_patterns,
             respect_gitignore,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,
@@ -1386,7 +1376,6 @@ impl CkMcpServer {
         let respect_gitignore = request.respect_gitignore.unwrap_or(true);
         let use_default_excludes = request.use_default_excludes.unwrap_or(true);
         let exclude_patterns = resolve_exclude_patterns(
-            &search_root,
             request.exclude_patterns.clone(),
             Some(use_default_excludes),
         );
@@ -1445,6 +1434,7 @@ impl CkMcpServer {
             exclude_patterns,
             include_patterns,
             respect_gitignore,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,
@@ -1522,7 +1512,6 @@ impl CkMcpServer {
         let respect_gitignore = request.respect_gitignore.unwrap_or(true);
         let use_default_excludes = request.use_default_excludes.unwrap_or(true);
         let exclude_patterns = resolve_exclude_patterns(
-            &search_root,
             request.exclude_patterns.clone(),
             Some(use_default_excludes),
         );
@@ -1582,6 +1571,7 @@ impl CkMcpServer {
             exclude_patterns,
             include_patterns,
             respect_gitignore,
+            use_ckignore: true,
             full_section: false,
             rerank: request.rerank.unwrap_or(false),
             rerank_model: request.rerank_model.clone(),
@@ -1836,6 +1826,7 @@ impl CkMcpServer {
             exclude_patterns: get_default_exclude_patterns(),
             include_patterns: Vec::new(),
             respect_gitignore: true,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -430,6 +430,7 @@ fn regex_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
         // Use ck_index's collect_files which respects gitignore
         let file_options = ck_core::FileCollectionOptions {
             respect_gitignore: options.respect_gitignore,
+            use_ckignore: true,
             exclude_patterns: options.exclude_patterns.clone(),
         };
         let collected = ck_index::collect_files(&options.path, &file_options)?;
@@ -1705,5 +1706,82 @@ mod tests {
         let (no_lines, no_endings_vec) = split_lines_with_endings(no_endings);
         assert_eq!(no_lines, vec!["single line"]);
         assert_eq!(no_endings_vec, vec![0]);
+    }
+
+    #[tokio::test]
+    async fn test_subdirectory_search_uses_parent_ckignore() {
+        // Regression test for issue where searching in subdirectory doesn't use parent .ckignore
+        // Bug: When searching ~/parent/subdir/, .ckignore is loaded from subdir (doesn't exist)
+        // instead of from parent (where index and .ckignore live)
+
+        let temp_dir = TempDir::new().unwrap();
+        let parent = temp_dir.path();
+        let subdir = parent.join("subproject");
+        fs::create_dir(&subdir).unwrap();
+
+        // Create .ckignore at parent level excluding *.tmp files
+        fs::write(parent.join(".ckignore"), "*.tmp\n").unwrap();
+
+        // Create test files in parent directory
+        fs::write(parent.join("parent.txt"), "searchable content in parent").unwrap();
+        fs::write(parent.join("ignored.tmp"), "this should not be indexed").unwrap();
+
+        // Create test files in subdirectory
+        fs::write(subdir.join("nested.txt"), "searchable content in subdir").unwrap();
+        fs::write(subdir.join("also_ignored.tmp"), "this should not be indexed either").unwrap();
+
+        // First, search from parent to create the index
+        let parent_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "searchable".to_string(),
+            path: parent.to_path_buf(),
+            top_k: Some(10),
+            threshold: Some(0.1),
+            ..Default::default()
+        };
+
+        let _ = search(&parent_options).await;
+
+        // Give indexing a moment to complete
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Now search from SUBDIRECTORY - this is where the bug occurs
+        // The engine should find parent .ck index and use parent .ckignore
+        // But currently it loads .ckignore from subdir (doesn't exist)
+        let subdir_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "content".to_string(),
+            path: subdir.clone(),
+            top_k: Some(10),
+            threshold: Some(0.1),
+            ..Default::default()
+        };
+
+        let results = search(&subdir_options).await.unwrap();
+
+        // ASSERTION 1: .tmp files should be excluded (currently FAILS due to bug)
+        let tmp_files: Vec<_> = results.iter()
+            .filter(|r| r.file.to_string_lossy().ends_with(".tmp"))
+            .collect();
+        assert!(
+            tmp_files.is_empty(),
+            "Bug: .tmp files were indexed despite parent .ckignore. Found {} .tmp files: {:?}",
+            tmp_files.len(),
+            tmp_files.iter().map(|r| &r.file).collect::<Vec<_>>()
+        );
+
+        // ASSERTION 2: Should find .txt files in subdirectory
+        let txt_in_subdir = results.iter()
+            .any(|r| r.file.ends_with("nested.txt"));
+        assert!(
+            txt_in_subdir,
+            "Should find nested.txt in subdirectory"
+        );
+
+        // ASSERTION 3: No .ck directory should be created in subdirectory
+        assert!(
+            !subdir.join(".ck").exists(),
+            "Should not create .ck directory in subdirectory"
+        );
     }
 }

--- a/ck-tui/src/app.rs
+++ b/ck-tui/src/app.rs
@@ -544,10 +544,9 @@ impl TuiApp {
         };
 
         // Use the centralized pattern builder from ck-core
+        // Note: .ckignore handling is now done by WalkBuilder hierarchically
         let exclude_patterns = ck_core::build_exclude_patterns(
-            Some(&self.state.search_path),
             &[],  // No additional excludes in TUI
-            true, // Use .ckignore
             true, // Use defaults
         );
 
@@ -576,6 +575,7 @@ impl TuiApp {
             exclude_patterns,
             include_patterns: Vec::new(),
             respect_gitignore: true,
+            use_ckignore: true,
             full_section: false,
             rerank: false,
             rerank_model: None,


### PR DESCRIPTION
## Problem

  Searching in subdirectories with MCP daemon was failing to find the full index, and indexing was taking significantly longer than expected due to repeatedly indexing files that should be ignored.

  **Root Cause:** WalkBuilder was not configured to load `.ckignore` files hierarchically. When searching or indexing from a subdirectory, only that subdirectory's `.ckignore` (if it exists) was considered, not
   parent directories' `.ckignore` files. This meant ignored files in subdirectories were being indexed and searched.

  ## Solution

  This PR implements hierarchical `.ckignore` support using WalkBuilder's built-in custom ignore filename feature, matching `.gitignore` behavior.

  ### Changes

  **Commit 1: Architectural Refactoring**
  - Replaced parameter threading anti-pattern with `FileCollectionOptions` config struct
  - Consolidated `respect_gitignore` and `exclude_patterns` parameters into a single struct
  - Updated `ensure_index_updated_with_progress()` to accept `FileCollectionOptions` instead of individual parameters
  - Updated all call sites across ck-engine, ck-cli, ck-index, and ck-tui

  **Commit 2: Hierarchical .ckignore Implementation**
  - Added `use_ckignore` field to `SearchOptions` and `FileCollectionOptions` structs (defaults to `true`)
  - Configured WalkBuilder to use `.add_custom_ignore_filename(".ckignore")` for hierarchical loading
  - Updated `build_exclude_patterns()` to remove manual `.ckignore` pattern loading (now handled by WalkBuilder)
  - Added `--no-ckignore` CLI flag for disabling `.ckignore` support when needed
  - Updated MCP server to always use hierarchical `.ckignore`
  - Added regression test `test_subdirectory_search_uses_parent_ckignore`

  ## Impact

  - `.ckignore` files are now loaded hierarchically from all parent directories up to the repository root
  - Significantly improves indexing performance by properly respecting ignore patterns
  - Fixes MCP daemon subdirectory search issues
  - Maintains backward compatibility (`.ckignore` enabled by default)

  ## Testing

  - All 159 existing tests pass
  - New regression test verifies hierarchical `.ckignore` behavior
  - Manually tested with large repositories (e.g., ~/qonto) showing dramatic performance improvements

  ## Migration Notes

  No breaking changes. The `use_ckignore` field defaults to `true`, maintaining existing behavior while enabling the hierarchical loading fix.