### PR TITLE
fix: regex_search should respect use_ckignore option

### DIFF
--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -1785,4 +1785,91 @@ mod tests {
             "Should not create .ck directory in subdirectory"
         );
     }
+
+    #[tokio::test]
+    async fn test_multiple_ckignore_files_merge_correctly() {
+        // Test that multiple .ckignore files in the hierarchy are all applied
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let parent = temp_dir.path();
+        let subdir = parent.join("subdir");
+        let deeper = subdir.join("deeper");
+        fs::create_dir(&subdir).unwrap();
+        fs::create_dir(&deeper).unwrap();
+
+        // Create hierarchical .ckignore files
+        fs::write(parent.join(".ckignore"), "*.log\n").unwrap();
+        fs::write(subdir.join(".ckignore"), "*.tmp\n").unwrap();
+        fs::write(deeper.join(".ckignore"), "*.cache\n").unwrap();
+
+        // Create test files at each level
+        fs::write(parent.join("root.txt"), "searchable").unwrap();
+        fs::write(parent.join("root.log"), "should be ignored").unwrap();
+
+        fs::write(subdir.join("mid.txt"), "searchable").unwrap();
+        fs::write(subdir.join("mid.log"), "should be ignored by parent").unwrap();
+        fs::write(subdir.join("mid.tmp"), "should be ignored by local").unwrap();
+
+        fs::write(deeper.join("deep.txt"), "searchable").unwrap();
+        fs::write(deeper.join("deep.log"), "should be ignored by grandparent").unwrap();
+        fs::write(deeper.join("deep.tmp"), "should be ignored by parent").unwrap();
+        fs::write(deeper.join("deep.cache"), "should be ignored by local").unwrap();
+
+        // Index from parent
+        let parent_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "searchable".to_string(),
+            path: parent.to_path_buf(),
+            top_k: Some(20),
+            threshold: Some(0.1),
+            ..Default::default()
+        };
+
+        let _ = search(&parent_options).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Search from deeper directory - should respect ALL three .ckignore files
+        let deeper_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "ignored".to_string(),
+            path: deeper.clone(),
+            top_k: Some(20),
+            threshold: Some(0.1),
+            ..Default::default()
+        };
+
+        let results = search(&deeper_options).await.unwrap();
+
+        // All ignored files should be excluded
+        let has_log = results
+            .iter()
+            .any(|r| r.file.to_string_lossy().ends_with(".log"));
+        let has_tmp = results
+            .iter()
+            .any(|r| r.file.to_string_lossy().ends_with(".tmp"));
+        let has_cache = results
+            .iter()
+            .any(|r| r.file.to_string_lossy().ends_with(".cache"));
+
+        assert!(
+            !has_log,
+            "*.log files should be excluded by parent .ckignore"
+        );
+        assert!(
+            !has_tmp,
+            "*.tmp files should be excluded by subdir .ckignore"
+        );
+        assert!(
+            !has_cache,
+            "*.cache files should be excluded by deeper .ckignore"
+        );
+
+        // Should still find .txt files
+        let has_txt = results
+            .iter()
+            .any(|r| r.file.to_string_lossy().ends_with(".txt"));
+        assert!(has_txt, "Should find .txt files (not ignored)");
+    }
 }

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -430,7 +430,7 @@ fn regex_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
         // Use ck_index's collect_files which respects gitignore
         let file_options = ck_core::FileCollectionOptions {
             respect_gitignore: options.respect_gitignore,
-            use_ckignore: true,
+            use_ckignore: options.use_ckignore,
             exclude_patterns: options.exclude_patterns.clone(),
         };
         let collected = ck_index::collect_files(&options.path, &file_options)?;

--- a/ck-index/src/lib.rs
+++ b/ck-index/src/lib.rs
@@ -2014,6 +2014,78 @@ mod tests {
         assert!(!test_path.join("level1").join("level2").exists());
         assert!(!test_path.join("level1").exists());
     }
+
+    #[test]
+    fn test_ckignore_works_without_gitignore() {
+        // Test that .ckignore is respected even when respect_gitignore is false
+        let temp_dir = TempDir::new().unwrap();
+        let test_path = temp_dir.path();
+
+        // Create .gitignore and .ckignore with different patterns
+        fs::write(test_path.join(".gitignore"), "*.git\n").unwrap();
+        fs::write(test_path.join(".ckignore"), "*.ck\n").unwrap();
+
+        // Create test files
+        fs::write(test_path.join("normal.txt"), "normal content").unwrap();
+        fs::write(test_path.join("ignored_by_git.git"), "git ignored").unwrap();
+        fs::write(test_path.join("ignored_by_ck.ck"), "ck ignored").unwrap();
+
+        // Test with respect_gitignore=false, use_ckignore=true
+        let options = ck_core::FileCollectionOptions {
+            respect_gitignore: false,
+            use_ckignore: true,
+            exclude_patterns: vec![],
+        };
+
+        let files = collect_files(test_path, &options).unwrap();
+        let file_names: Vec<String> = files
+            .iter()
+            .filter_map(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string())
+            .collect();
+
+        // Should find normal.txt
+        assert!(
+            file_names.contains(&"normal.txt".to_string()),
+            "Should find normal.txt"
+        );
+
+        // Should find .git file (gitignore not respected)
+        assert!(
+            file_names.contains(&"ignored_by_git.git".to_string()),
+            "Should find .git file when respect_gitignore=false"
+        );
+
+        // Should NOT find .ck file (ckignore is respected)
+        assert!(
+            !file_names.contains(&"ignored_by_ck.ck".to_string()),
+            "Should NOT find .ck file when use_ckignore=true"
+        );
+
+        // Test with both disabled
+        let options_both_disabled = ck_core::FileCollectionOptions {
+            respect_gitignore: false,
+            use_ckignore: false,
+            exclude_patterns: vec![],
+        };
+
+        let files_all = collect_files(test_path, &options_both_disabled).unwrap();
+        let file_names_all: Vec<String> = files_all
+            .iter()
+            .filter_map(|p| p.file_name())
+            .map(|n| n.to_string_lossy().to_string())
+            .collect();
+
+        // Should find ALL files when both are disabled
+        assert!(
+            file_names_all.contains(&"ignored_by_git.git".to_string()),
+            "Should find .git file"
+        );
+        assert!(
+            file_names_all.contains(&"ignored_by_ck.ck".to_string()),
+            "Should find .ck file when use_ckignore=false"
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
Sorry for not including this in the original PR, but I asked claude for a few additional tests and got a free bugfix.