### PR TITLE
$94 Adds Dart language support to ck-chunk crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,6 +516,7 @@ dependencies = [
  "tracing",
  "tree-sitter",
  "tree-sitter-c-sharp",
+ "tree-sitter-dart",
  "tree-sitter-go",
  "tree-sitter-haskell",
  "tree-sitter-python",
@@ -4388,6 +4389,16 @@ checksum = "67f06accca7b45351758663b8215089e643d53bd9a660ce0349314263737fcb0"
 dependencies = [
  "cc",
  "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-dart"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f1f70b80ce41343e14aafcef67b5ba2e9de89587535b4aabbabb8036f4e38a"
+dependencies = [
+ "cc",
+ "tree-sitter",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tree-sitter-ruby = "0.23"
 tree-sitter-go = "0.25"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-zig = "1.1"
+tree-sitter-dart = "0.0.4"
 fastembed = { version = "5.1", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries"] }
 openssl = { version = "0.10" }
 tempfile = "3.8"

--- a/ck-chunk/Cargo.toml
+++ b/ck-chunk/Cargo.toml
@@ -25,6 +25,7 @@ tree-sitter-ruby = { workspace = true }
 tree-sitter-go = { workspace = true }
 tree-sitter-c-sharp = { workspace = true }
 tree-sitter-zig = { workspace = true }
+tree-sitter-dart = { workspace = true }
 tracing = { workspace = true }
 hf-hub = "0.3"
 tokenizers = { version = "0.22", default-features = false, features = ["onig", "progressbar"] }

--- a/ck-chunk/queries/dart/tags.scm
+++ b/ck-chunk/queries/dart/tags.scm
@@ -1,0 +1,14 @@
+; Dart chunk definitions using tree-sitter queries
+
+; Classes, Mixins, Enums
+(class_definition) @definition.class
+(mixin_declaration) @definition.class
+(enum_declaration) @definition.class
+
+; Functions, Methods, Constructors
+(lambda_expression) @definition.function
+(class_member_definition) @definition.method
+; (constructor_signature) @definition.method 
+
+; Top-level variables and constants (module-level)
+(local_variable_declaration) @module.text

--- a/ck-chunk/src/lib.rs
+++ b/ck-chunk/src/lib.rs
@@ -136,6 +136,7 @@ pub enum ParseableLanguage {
     Go,
     CSharp,
     Zig,
+    Dart,
 }
 
 impl std::fmt::Display for ParseableLanguage {
@@ -150,6 +151,7 @@ impl std::fmt::Display for ParseableLanguage {
             ParseableLanguage::Go => "go",
             ParseableLanguage::CSharp => "csharp",
             ParseableLanguage::Zig => "zig",
+            ParseableLanguage::Dart => "dart",
         };
         write!(f, "{}", name)
     }
@@ -169,6 +171,7 @@ impl TryFrom<ck_core::Language> for ParseableLanguage {
             ck_core::Language::Go => Ok(ParseableLanguage::Go),
             ck_core::Language::CSharp => Ok(ParseableLanguage::CSharp),
             ck_core::Language::Zig => Ok(ParseableLanguage::Zig),
+            ck_core::Language::Dart => Ok(ParseableLanguage::Dart),
             _ => Err(anyhow::anyhow!(
                 "Language {:?} is not supported for parsing",
                 lang
@@ -347,6 +350,12 @@ fn chunk_generic_with_token_config(text: &str, model_name: Option<&str>) -> Resu
 }
 
 pub(crate) fn tree_sitter_language(language: ParseableLanguage) -> Result<tree_sitter::Language> {
+    // tree-sitter-dart v0.0.4 uses an older API that returns Language directly,
+    // while newer bindings (v0.24+) require calling .into() on a factory struct.
+    if language == ParseableLanguage::Dart {
+        return Ok(tree_sitter_dart::language());
+    }
+
     let ts_language = match language {
         ParseableLanguage::Python => tree_sitter_python::LANGUAGE,
         ParseableLanguage::TypeScript | ParseableLanguage::JavaScript => {
@@ -358,6 +367,7 @@ pub(crate) fn tree_sitter_language(language: ParseableLanguage) -> Result<tree_s
         ParseableLanguage::Go => tree_sitter_go::LANGUAGE,
         ParseableLanguage::CSharp => tree_sitter_c_sharp::LANGUAGE,
         ParseableLanguage::Zig => tree_sitter_zig::LANGUAGE,
+        ParseableLanguage::Dart => unreachable!("Handled above via early return"),
     };
 
     Ok(ts_language.into())
@@ -781,6 +791,20 @@ fn chunk_type_for_node(
                 | "interface_declaration"
                 | "variable_declaration"
         ),
+        ParseableLanguage::Dart => matches!(
+            kind,
+            "class_definition"
+                | "class_declaration"
+                | "mixin_declaration"
+                | "enum_declaration"
+                | "function_declaration"
+                | "method_declaration"
+                | "constructor_declaration"
+                | "variable_declaration"
+                | "local_variable_declaration"
+                | "lambda_expression"
+                | "class_member_definition"
+        ),
         ParseableLanguage::Zig => matches!(
             kind,
             "function_declaration"
@@ -1098,6 +1122,9 @@ fn display_name_for_node(
         ParseableLanguage::Go => find_identifier(node, source, &["identifier", "type_identifier"]),
         ParseableLanguage::CSharp => find_identifier(node, source, &["identifier"]),
         ParseableLanguage::Zig => find_identifier(node, source, &["identifier"]),
+        ParseableLanguage::Dart => {
+            find_identifier(node, source, &["identifier", "type_identifier"])
+        }
     }
 }
 
@@ -1195,6 +1222,12 @@ fn is_method_context(node: tree_sitter::Node<'_>, language: ParseableLanguage) -
     const TYPESCRIPT_CONTAINERS: &[&str] = &["class_body", "class_declaration"];
     const RUBY_CONTAINERS: &[&str] = &["class", "module"];
     const RUST_CONTAINERS: &[&str] = &["impl_item", "trait_item"];
+    const DART_CONTAINERS: &[&str] = &[
+        "class_definition",
+        "class_declaration",
+        "mixin_declaration",
+        "enum_declaration",
+    ];
 
     match language {
         ParseableLanguage::Python => ancestor_has_kind(node, PYTHON_CONTAINERS),
@@ -1207,6 +1240,7 @@ fn is_method_context(node: tree_sitter::Node<'_>, language: ParseableLanguage) -
         ParseableLanguage::CSharp => false,
         ParseableLanguage::Haskell => false,
         ParseableLanguage::Zig => false,
+        ParseableLanguage::Dart => ancestor_has_kind(node, DART_CONTAINERS),
     }
 }
 

--- a/ck-core/src/lib.rs
+++ b/ck-core/src/lib.rs
@@ -53,6 +53,7 @@ pub enum Language {
     Swift,
     Kotlin,
     Zig,
+    Dart,
     Pdf,
 }
 
@@ -76,6 +77,7 @@ impl Language {
             "swift" => Some(Language::Swift),
             "kt" | "kts" => Some(Language::Kotlin),
             "zig" => Some(Language::Zig),
+            "dart" => Some(Language::Dart),
             "pdf" => Some(Language::Pdf),
             _ => None,
         }
@@ -106,6 +108,7 @@ impl std::fmt::Display for Language {
             Language::Swift => "swift",
             Language::Kotlin => "kotlin",
             Language::Zig => "zig",
+            Language::Dart => "dart",
             Language::Pdf => "pdf",
         };
         write!(f, "{}", name)


### PR DESCRIPTION
This change introduces support for the Dart programming language in the ck-chunk crate. It includes adding the `tree-sitter-dart` dependency, updating language enums and matching logic, and creating a Dart-specific tags query.

### Changes

- Added `tree-sitter-dart` as a dependency in `Cargo.toml` and `Cargo.lock`.
- Added `Dart` variant to the `ParseableLanguage` enum in `ck-chunk/src/lib.rs`.
- Modified `TryFrom` and `Display` implementations for `ParseableLanguage` to include Dart.
- Updated `tree_sitter_language` function to return the `tree_sitter_dart` language.
- Added a new `tags.scm` file for Dart in `ck-chunk/queries/dart/` containing tree-sitter queries for identifying Dart language constructs.
- Modified `chunk_type_for_node` to include Dart-specific node kinds for chunking.
- Modified `display_name_for_node` to include Dart-specific identifier types.
- Modified `is_method_context` to include Dart container types.
- Added a test case `dart_queries_capture_core_constructs` in `ck-chunk/src/query_chunker.rs` to verify the Dart query's functionality.
- Added `Dart` to the `Language` enum in `ck-core/src/lib.rs`.
- Updated `Language` enum's `from_str` and `Display` implementations to include Dart.

### Impact

- Introduces support for parsing and chunking Dart code.
- Extends the functionality of the `ck-chunk` crate to handle Dart syntax.
- The new test case verifies the functionality of the Dart queries.
- Dependencies on `tree-sitter-dart` are introduced.