### PR TITLE
Fix Windows checksum format for package manager compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -182,7 +182,8 @@ jobs:
       - name: Generate SHA256
         run: |
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            certutil -hashfile ${{ env.ARCHIVE_NAME }}.zip SHA256 > ${{ env.ARCHIVE_NAME }}.zip.sha256
+            # Use PowerShell to generate GNU coreutils-compatible format
+            powershell -Command "(Get-FileHash -Algorithm SHA256 '${{ env.ARCHIVE_NAME }}.zip').Hash.ToLower() + '  ${{ env.ARCHIVE_NAME }}.zip'" > ${{ env.ARCHIVE_NAME }}.zip.sha256
           else
             if [ "${{ matrix.os }}" = "macos-latest" ]; then
               shasum -a 256 ${{ env.ARCHIVE_NAME }}.tar.gz > ${{ env.ARCHIVE_NAME }}.tar.gz.sha256


### PR DESCRIPTION
Discovered when integrating with aqua, which verifies checksums on install. The Windows workflow was redirecting the raw output of CertUtil into the checksum file:

    SHA256 hash of ck-0.7.0-x86_64-pc-windows-msvc.zip:
    4bf493a458ee79318f47f3bdc28082bde48aa5ee1d26a399a96a2736dfea1711
    CertUtil: -hashfile command completed successfully.

This is human-readable output, not a machine-parseable format. Use PowerShell's Get-FileHash to produce the GNU coreutils format that package managers expect:

    4bf493a458ee79318f47f3bdc28082bde48aa5ee1d26a399a96a2736dfea1711  ck-0.7.0-x86_64-pc-windows-msvc.zip