### PR TITLE
fix(mcp): make tool schemas compatible with Google Gemini API

### DIFF
--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -135,7 +135,9 @@ pub struct SemanticSearchRequest {
     pub path: String,
     pub top_k: Option<usize>,
     pub threshold: Option<f32>,
+    #[schemars(with = "Vec<String>")]
     pub include_patterns: Option<Vec<String>>,
+    #[schemars(with = "Vec<String>")]
     pub exclude_patterns: Option<Vec<String>>,
     pub respect_gitignore: Option<bool>,
     pub use_default_excludes: Option<bool>,
@@ -160,7 +162,9 @@ pub struct RegexSearchRequest {
     pub path: String,
     pub ignore_case: Option<bool>,
     pub context: Option<usize>,
+    #[schemars(with = "Vec<String>")]
     pub include_patterns: Option<Vec<String>>,
+    #[schemars(with = "Vec<String>")]
     pub exclude_patterns: Option<Vec<String>>,
     pub respect_gitignore: Option<bool>,
     pub use_default_excludes: Option<bool>,
@@ -179,7 +183,9 @@ pub struct HybridSearchRequest {
     pub path: String,
     pub top_k: Option<usize>,
     pub threshold: Option<f32>,
+    #[schemars(with = "Vec<String>")]
     pub include_patterns: Option<Vec<String>>,
+    #[schemars(with = "Vec<String>")]
     pub exclude_patterns: Option<Vec<String>>,
     pub respect_gitignore: Option<bool>,
     pub use_default_excludes: Option<bool>,
@@ -204,7 +210,9 @@ pub struct LexicalSearchRequest {
     pub path: String,
     pub top_k: Option<usize>,
     pub threshold: Option<f32>,
+    #[schemars(with = "Vec<String>")]
     pub include_patterns: Option<Vec<String>>,
+    #[schemars(with = "Vec<String>")]
     pub exclude_patterns: Option<Vec<String>>,
     pub respect_gitignore: Option<bool>,
     pub use_default_excludes: Option<bool>,


### PR DESCRIPTION
## Summary

The Google Gemini API rejects JSON Schema union types like `["array", "null"]` in tool function declarations, causing **400 Bad Request** errors when any MCP client with CK tools tries to use Gemini models.

## Problem

When CK's MCP server exposes tool schemas to LLM providers, `Option<Vec<String>>` fields (`include_patterns`, `exclude_patterns`) generate:

```json
{
  "type": ["array", "null"],
  "items": { "type": "string" }
}
```

This is valid JSON Schema but Gemini's API validates strictly:
```
GenerateContentRequest.tools[0].function_declarations[N].parameters.properties[include_patterns].items: 
  field predicate failed: $type == Type.ARRAY
```

## Fix

Add `#[schemars(with = "Vec<String>")]` to all 8 `Option<Vec<String>>` fields across the 4 search request structs (`SemanticSearchRequest`, `RegexSearchRequest`, `HybridSearchRequest`, `LexicalSearchRequest`).

This generates `"type": "array"` instead of `"type": ["array", "null"]` while keeping the Rust type `Option<Vec<String>>` unchanged — fully backward compatible.

## Tested

- ✅ `google/gemini-3.1-pro-preview` — responds correctly
- ✅ `google/antigravity-gemini-3-flash` — responds correctly  
- ✅ Anthropic models — still work (they were already fine)
- ✅ `cargo test` passes
- ✅ `cargo build --release` succeeds