### PR TITLE
fix(ck-engine): apply path scope before top_k in semantic search

### DIFF
--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -1854,4 +1854,97 @@ mod tests {
             .any(|r| r.file.to_string_lossy().ends_with(".txt"));
         assert!(has_txt, "Should find .txt files (not ignored)");
     }
+
+    // Default model config is fastembed; without that feature ck-embed
+    // falls back to DummyEmbedder (zero vectors) and the assertions can't
+    // distinguish a scoped match from no match at all.
+    #[cfg(feature = "fastembed")]
+    #[tokio::test]
+    async fn test_scoped_search_does_not_lose_results_to_global_top_k() {
+        // Regression test for the bug where scoped semantic search applied
+        // top_k BEFORE the path filter, so a small top_k against a whole-
+        // codebase index could return zero matches when the global top
+        // results all lived outside the requested scope.
+        //
+        // Reproduction:
+        //   - Index a parent dir that contains many files about TOPIC_A
+        //     (so they dominate the global top_k for that query)
+        //   - Search inside a sibling subdir that contains a file about
+        //     TOPIC_A, with top_k smaller than the TOPIC_A file count
+        //   - Before the fix: zero results inside subdir
+        //   - After the fix:  the in-scope file is returned
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let parent = temp_dir.path();
+        let noisy = parent.join("noisy");
+        let scoped = parent.join("scoped");
+        fs::create_dir(&noisy).unwrap();
+        fs::create_dir(&scoped).unwrap();
+
+        // 8 files in noisy/ that all match the query "database connection".
+        // top_k=3 will be entirely consumed by these globally.
+        for i in 0..8 {
+            fs::write(
+                noisy.join(format!("noise_{i}.txt")),
+                format!(
+                    "function open_database_connection_{i}() {{\n    \
+                     // establish a database connection to postgres\n    \
+                     // handle database connection errors gracefully\n}}\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        // One in-scope file that also matches the query
+        fs::write(
+            scoped.join("target.txt"),
+            "function connect() {\n    \
+             // open a database connection to the primary store\n    \
+             // database connection pool config goes here\n}\n",
+        )
+        .unwrap();
+
+        // Index from parent so .ck lives at parent root and covers both subdirs.
+        let index_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "database connection".to_string(),
+            path: parent.to_path_buf(),
+            top_k: Some(20),
+            threshold: Some(0.0),
+            ..Default::default()
+        };
+        let _ = search(&index_options).await;
+        tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+        // Now search scoped to `scoped/` with a small top_k. The bug:
+        // the 3 global top results all live in `noisy/`, so the path
+        // filter rejects all of them and we get [].
+        let scoped_options = SearchOptions {
+            mode: SearchMode::Semantic,
+            query: "database connection".to_string(),
+            path: scoped.clone(),
+            top_k: Some(3),
+            threshold: Some(0.0),
+            ..Default::default()
+        };
+
+        let results = search(&scoped_options).await.unwrap();
+
+        assert!(
+            !results.is_empty(),
+            "Scoped search returned zero results — top_k was applied \
+             before the path filter (the bug this test guards against)."
+        );
+        let all_in_scope = results.iter().all(|r| {
+            r.file.starts_with(&scoped)
+                || r.file.canonicalize().ok() == scoped.join("target.txt").canonicalize().ok()
+        });
+        assert!(
+            all_in_scope,
+            "Some results leaked out of the requested scope: {:?}",
+            results.iter().map(|r| &r.file).collect::<Vec<_>>()
+        );
+    }
 }

--- a/ck-engine/src/semantic_v3.rs
+++ b/ck-engine/src/semantic_v3.rs
@@ -38,6 +38,14 @@ pub async fn semantic_search_v3_with_progress(
         callback("Loading embeddings from sidecar files...");
     }
 
+    // Build the path scope filter once, up front. Previously this was
+    // applied AFTER top_k inside the iteration loop, so a whole-codebase
+    // index plus a narrow `path=` query could return zero matches when
+    // the global top_k results all lived outside the requested scope.
+    // Filtering at collection time fixes that and skips embedding loads
+    // for chunks we'd discard anyway.
+    let scope = PathScope::new(&options.path);
+
     // Collect all sidecar files and their embeddings
     let mut file_chunks: Vec<(std::path::PathBuf, ck_index::ChunkEntry)> = Vec::new();
 
@@ -51,6 +59,9 @@ pub async fn semantic_search_v3_with_progress(
                     let original_file = reconstruct_original_path(path, &index_dir, &index_root);
                     if let Some(original_file) = original_file {
                         if !super::path_matches_include(&original_file, &options.include_patterns) {
+                            continue;
+                        }
+                        if !scope.contains(&original_file) {
                             continue;
                         }
                         for chunk in index_entry.chunks {
@@ -139,34 +150,6 @@ pub async fn semantic_search_v3_with_progress(
         let is_below_threshold = options
             .threshold
             .is_some_and(|threshold| similarity < threshold);
-
-        // Check if we're filtering by a specific file or directory (apply to both above/below threshold)
-        let passes_path_filter = if options.path.is_file() {
-            let target_file = options
-                .path
-                .canonicalize()
-                .unwrap_or_else(|_| options.path.clone());
-            let result_file = file_path
-                .canonicalize()
-                .unwrap_or_else(|_| file_path.clone());
-            result_file == target_file
-        } else if options.path != Path::new(".") {
-            // Filter by directory path - only include files within the specified directory
-            let target_dir = options
-                .path
-                .canonicalize()
-                .unwrap_or_else(|_| options.path.clone());
-            let result_file = file_path
-                .canonicalize()
-                .unwrap_or_else(|_| file_path.clone());
-            result_file.starts_with(&target_dir)
-        } else {
-            true
-        };
-
-        if !passes_path_filter {
-            continue;
-        }
 
         // Extract content from the file using the span, skip if file doesn't exist
         let content = if options.full_section {
@@ -282,6 +265,44 @@ pub async fn semantic_search_v3_with_progress(
     })
 }
 
+/// Scope a semantic query to a file, a directory, or the whole index.
+///
+/// Cached canonical form of `options.path` so per-chunk membership
+/// checks don't re-canonicalize on every iteration.
+enum PathScope {
+    All,
+    File(std::path::PathBuf),
+    Dir(std::path::PathBuf),
+}
+
+impl PathScope {
+    fn new(path: &Path) -> Self {
+        if path == Path::new(".") {
+            return Self::All;
+        }
+        let canonical = path.canonicalize().unwrap_or_else(|_| path.to_path_buf());
+        if path.is_file() {
+            Self::File(canonical)
+        } else {
+            Self::Dir(canonical)
+        }
+    }
+
+    fn contains(&self, file: &Path) -> bool {
+        match self {
+            Self::All => true,
+            Self::File(target) => {
+                let canonical = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+                canonical == *target
+            }
+            Self::Dir(target) => {
+                let canonical = file.canonicalize().unwrap_or_else(|_| file.to_path_buf());
+                canonical.starts_with(target)
+            }
+        }
+    }
+}
+
 fn reconstruct_original_path(
     sidecar_path: &Path,
     index_dir: &Path,
@@ -317,5 +338,50 @@ fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
         0.0
     } else {
         dot_product / (norm_a * norm_b)
+    }
+}
+
+#[cfg(test)]
+mod path_scope_tests {
+    use super::PathScope;
+    use std::fs;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    #[test]
+    fn all_matches_anything() {
+        let scope = PathScope::new(Path::new("."));
+        assert!(scope.contains(Path::new("/tmp/whatever")));
+        assert!(scope.contains(Path::new("./relative")));
+    }
+
+    #[test]
+    fn dir_matches_descendants_only() {
+        let tmp = TempDir::new().unwrap();
+        let scoped = tmp.path().join("inside");
+        let outside = tmp.path().join("outside");
+        fs::create_dir(&scoped).unwrap();
+        fs::create_dir(&outside).unwrap();
+        let inside_file = scoped.join("a.txt");
+        let outside_file = outside.join("b.txt");
+        fs::write(&inside_file, "x").unwrap();
+        fs::write(&outside_file, "y").unwrap();
+
+        let scope = PathScope::new(&scoped);
+        assert!(scope.contains(&inside_file));
+        assert!(!scope.contains(&outside_file));
+    }
+
+    #[test]
+    fn file_matches_exactly_that_file() {
+        let tmp = TempDir::new().unwrap();
+        let target = tmp.path().join("target.txt");
+        let other = tmp.path().join("other.txt");
+        fs::write(&target, "x").unwrap();
+        fs::write(&other, "y").unwrap();
+
+        let scope = PathScope::new(&target);
+        assert!(scope.contains(&target));
+        assert!(!scope.contains(&other));
     }
 }


### PR DESCRIPTION
## Problem

\`semantic_search_v3\` computed cosine similarity for every chunk in the index, sorted them, took the **global** top_k, and only THEN applied the path filter. With a whole-codebase index plus a narrow \`path=\` query, the global top_k could be entirely consumed by chunks outside the requested scope — leaving the path filter with nothing to keep and returning an empty result set even though the in-scope file had great matches.

Found via code review (task #10 in the session task list).

## Fix

1. **Build a \`PathScope\` (All / Dir / File) once up-front** with the target canonicalized once.
2. **Apply scope at sidecar-collection time** — before we even read embeddings or compute similarities. Earliest possible filter.
3. **Remove the now-redundant per-result path check** from the iteration loop, which had also been re-canonicalizing \`options.path\` on every iteration.

## Tests

- **3 \`PathScope\` unit tests** (\`All\` / \`Dir\` / \`File\`). Run under \`--no-default-features\` too — no embedder dependency.
- **1 integration regression test** \`test_scoped_search_does_not_lose_results_to_global_top_k\`: indexes 8 noisy files about \"database connection\" in \`noisy/\`, plus 1 in-scope file in \`scoped/\`, then searches scope=\`scoped/\` with \`top_k=3\`. Pre-fix: empty result. Post-fix: in-scope file present. Gated on \`fastembed\` since it needs a real embedder.

## Test plan

- [x] \`cargo test -p ck-engine --no-default-features\` — 18 passed (was 15)
- [x] \`cargo clippy -p ck-engine --no-default-features --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [ ] CI green on this PR (fastembed-feature test also passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)