### PR TITLE
fix(mcp): sandbox tool handlers to allowed filesystem roots

### DIFF
--- a/ck-cli/src/mcp/context.rs
+++ b/ck-cli/src/mcp/context.rs
@@ -1,19 +1,29 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use tokio::sync::{Mutex, RwLock};
 use tracing::info;
 
 use ck_core::{SearchOptions, get_default_exclude_patterns};
+use rmcp::ErrorData;
 
 use super::McpResult;
 use super::cache::StatsCache;
 use super::session::SessionManager;
 
+/// Environment variable that lets an operator extend the MCP sandbox
+/// to additional roots (colon-separated, like `PATH`). Each entry must
+/// resolve to an existing directory or it's ignored with a warning.
+pub const ALLOWED_ROOTS_ENV: &str = "CK_MCP_ALLOWED_ROOTS";
+
 /// Shared context for the MCP server managing resources and configuration
 #[derive(Clone)]
 pub struct McpContext {
     pub cwd: PathBuf,
+    /// Canonical filesystem roots the MCP server is permitted to read.
+    /// Every tool handler must route incoming `request.path` through
+    /// [`McpContext::resolve_request_path`] which enforces containment.
+    pub allowed_roots: Vec<PathBuf>,
     pub stats_cache: StatsCache,
     pub session_manager: SessionManager,
     #[allow(dead_code)]
@@ -27,6 +37,31 @@ pub struct McpContext {
 impl McpContext {
     pub fn new(cwd: PathBuf) -> McpResult<Self> {
         info!("Initializing MCP context for directory: {}", cwd.display());
+
+        // Sandbox roots: always include the canonical cwd, optionally
+        // extend via CK_MCP_ALLOWED_ROOTS. Canonicalize so symlink
+        // tricks can't smuggle a path through containment checks.
+        let cwd_canonical = cwd.canonicalize().unwrap_or_else(|_| cwd.clone());
+        let mut allowed_roots: Vec<PathBuf> = vec![cwd_canonical.clone()];
+        if let Ok(extra) = std::env::var(ALLOWED_ROOTS_ENV) {
+            for entry in extra.split(':').filter(|s| !s.is_empty()) {
+                match PathBuf::from(entry).canonicalize() {
+                    Ok(root) if root.is_dir() => {
+                        if !allowed_roots.iter().any(|r| r == &root) {
+                            info!("MCP sandbox root added from env: {}", root.display());
+                            allowed_roots.push(root);
+                        }
+                    }
+                    Ok(root) => tracing::warn!(
+                        "{ALLOWED_ROOTS_ENV} entry is not a directory, ignoring: {}",
+                        root.display()
+                    ),
+                    Err(e) => tracing::warn!(
+                        "{ALLOWED_ROOTS_ENV} entry could not be resolved, ignoring: {entry} ({e})"
+                    ),
+                }
+            }
+        }
 
         let default_search_options = SearchOptions {
             mode: ck_core::SearchMode::Semantic,
@@ -61,7 +96,8 @@ impl McpContext {
         };
 
         Ok(Self {
-            cwd,
+            cwd: cwd_canonical,
+            allowed_roots,
             stats_cache: StatsCache::default(), // 30-second TTL for MCP responsiveness
             session_manager: SessionManager::default(), // 5-minute TTL for search sessions
             #[allow(dead_code)]
@@ -71,6 +107,48 @@ impl McpContext {
             #[allow(dead_code)]
             default_search_options,
         })
+    }
+
+    /// Resolve a `request.path` string into a canonical PathBuf, rejecting
+    /// anything that escapes the MCP sandbox.
+    ///
+    /// Containment is checked against the canonical form, so `..` traversal,
+    /// symlinks pointing outside, and absolute escape paths are all rejected.
+    /// The path must exist — non-existent paths return `invalid_params`.
+    pub fn resolve_request_path(&self, raw: &str) -> Result<PathBuf, ErrorData> {
+        if raw.is_empty() {
+            return Err(ErrorData::invalid_params(
+                "path must not be empty".to_string(),
+                None,
+            ));
+        }
+        let requested = if Path::new(raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            self.cwd.join(raw)
+        };
+        if !requested.exists() {
+            return Err(ErrorData::invalid_params(
+                format!("path does not exist: {raw}"),
+                None,
+            ));
+        }
+        let canonical = requested.canonicalize().map_err(|e| {
+            ErrorData::invalid_params(format!("could not resolve path '{raw}': {e}"), None)
+        })?;
+        if !self
+            .allowed_roots
+            .iter()
+            .any(|root| canonical == *root || canonical.starts_with(root))
+        {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "path is outside the MCP allowed roots (set {ALLOWED_ROOTS_ENV} to extend): {raw}"
+                ),
+                None,
+            ));
+        }
+        Ok(canonical)
     }
 
     /// Get or create an index lock for the specified directory
@@ -110,5 +188,122 @@ impl McpContext {
         } else {
             false
         }
+    }
+}
+
+#[cfg(test)]
+mod sandbox_tests {
+    use super::McpContext;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn ctx(root: &std::path::Path) -> McpContext {
+        McpContext::new(root.to_path_buf()).expect("context")
+    }
+
+    #[test]
+    fn accepts_existing_path_inside_root() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        let f = sub.join("a.txt");
+        fs::write(&f, "x").unwrap();
+
+        let c = ctx(tmp.path());
+        let resolved = c
+            .resolve_request_path(f.to_str().unwrap())
+            .expect("inside root must succeed");
+        assert_eq!(resolved.canonicalize().unwrap(), f.canonicalize().unwrap(),);
+    }
+
+    #[test]
+    fn accepts_relative_path_inside_root() {
+        let tmp = TempDir::new().unwrap();
+        let sub = tmp.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+        let c = ctx(tmp.path());
+        let resolved = c
+            .resolve_request_path("sub")
+            .expect("relative path inside root");
+        assert!(resolved.starts_with(tmp.path().canonicalize().unwrap()));
+    }
+
+    #[test]
+    fn rejects_absolute_path_outside_root() {
+        let tmp_root = TempDir::new().unwrap();
+        let tmp_outside = TempDir::new().unwrap();
+        let outside_file = tmp_outside.path().join("secret.txt");
+        fs::write(&outside_file, "top-secret").unwrap();
+
+        let c = ctx(tmp_root.path());
+        let err = c
+            .resolve_request_path(outside_file.to_str().unwrap())
+            .expect_err("absolute path outside root must be rejected");
+        assert!(format!("{err:?}").contains("outside the MCP allowed roots"));
+    }
+
+    #[test]
+    fn rejects_dot_dot_escape() {
+        let tmp_root = TempDir::new().unwrap();
+        let sub = tmp_root.path().join("sub");
+        fs::create_dir(&sub).unwrap();
+
+        // Build a relative path that climbs out via ..
+        // sub/../../  → lands above the sandbox root.
+        let c = McpContext::new(sub.clone()).expect("ctx");
+        let parent_of_root = tmp_root.path().parent().expect("tmp has parent");
+        // resolve_request_path joins relative against cwd (sub), so
+        // "../../" from sub lands in tmp_root's parent, outside the
+        // sandbox. The path must exist for the function to even reach
+        // the containment check, so use parent_of_root directly which
+        // is the tmpdir base and definitely exists.
+        let _ = parent_of_root; // (kept for readability)
+        let err = c
+            .resolve_request_path("../../")
+            .expect_err(".. escape must be rejected");
+        assert!(format!("{err:?}").contains("outside the MCP allowed roots"));
+    }
+
+    #[test]
+    fn rejects_symlink_pointing_outside_root() {
+        // Symlinks should be resolved by canonicalize() and then fail
+        // the containment check. Skip on platforms where symlinks need
+        // privileges (Windows) — this test runs on Unix CI.
+        #[cfg(unix)]
+        {
+            let tmp_root = TempDir::new().unwrap();
+            let tmp_outside = TempDir::new().unwrap();
+            let outside_file = tmp_outside.path().join("secret.txt");
+            fs::write(&outside_file, "top-secret").unwrap();
+
+            let link = tmp_root.path().join("escape");
+            std::os::unix::fs::symlink(&outside_file, &link).unwrap();
+
+            let c = ctx(tmp_root.path());
+            let err = c
+                .resolve_request_path(link.to_str().unwrap())
+                .expect_err("symlink pointing outside must be rejected");
+            assert!(format!("{err:?}").contains("outside the MCP allowed roots"));
+        }
+    }
+
+    #[test]
+    fn rejects_empty_path() {
+        let tmp = TempDir::new().unwrap();
+        let c = ctx(tmp.path());
+        let err = c
+            .resolve_request_path("")
+            .expect_err("empty path must be rejected");
+        assert!(format!("{err:?}").contains("must not be empty"));
+    }
+
+    #[test]
+    fn rejects_nonexistent_path() {
+        let tmp = TempDir::new().unwrap();
+        let c = ctx(tmp.path());
+        let err = c
+            .resolve_request_path("definitely-does-not-exist")
+            .expect_err("nonexistent path must be rejected");
+        assert!(format!("{err:?}").contains("does not exist"));
     }
 }

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -987,7 +987,8 @@ impl CkMcpServer {
         let path = request.path;
         let top_k = request.top_k;
         let threshold = request.threshold;
-        let path_buf = PathBuf::from(path);
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
         let search_root = if path_buf.is_dir() {
             path_buf.clone()
         } else {
@@ -1010,14 +1011,6 @@ impl CkMcpServer {
         // Clone values before they're moved into SearchOptions
         let query_clone = query.clone();
         let path_clone = path_buf.clone();
-
-        // Validate path exists
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
 
         // Extract pagination config
         let config = Self::extract_pagination_config(
@@ -1226,7 +1219,8 @@ impl CkMcpServer {
         let path = request.path;
         let top_k = request.top_k;
         let threshold = request.threshold;
-        let path_buf = PathBuf::from(path);
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
         let search_root = if path_buf.is_dir() {
             path_buf.clone()
         } else {
@@ -1248,13 +1242,6 @@ impl CkMcpServer {
 
         let query_clone = query.clone();
         let path_clone = path_buf.clone();
-
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
 
         let config = Self::extract_pagination_config(
             request.page_size,
@@ -1359,7 +1346,8 @@ impl CkMcpServer {
         let path = request.path;
         let ignore_case = request.ignore_case;
         let context = request.context;
-        let path_buf = PathBuf::from(path);
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
         let search_root = if path_buf.is_dir() {
             path_buf.clone()
         } else {
@@ -1382,14 +1370,6 @@ impl CkMcpServer {
         // Clone values before they're moved into SearchOptions
         let pattern_clone = pattern.clone();
         let path_clone = path_buf.clone();
-
-        // Validate path exists
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
 
         let context_lines = context.unwrap_or(0);
 
@@ -1493,7 +1473,8 @@ impl CkMcpServer {
         let path = request.path;
         let top_k = request.top_k;
         let threshold = request.threshold;
-        let path_buf = PathBuf::from(path);
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
         let search_root = if path_buf.is_dir() {
             path_buf.clone()
         } else {
@@ -1516,14 +1497,6 @@ impl CkMcpServer {
         // Clone values before they're moved into SearchOptions
         let query_clone = query.clone();
         let path_clone = path_buf.clone();
-
-        // Validate path exists
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
 
         // Extract pagination config
         let config = Self::extract_pagination_config(
@@ -1625,15 +1598,8 @@ impl CkMcpServer {
         _peer: Option<Peer<RoleServer>>,
     ) -> Result<(String, Value), ErrorData> {
         let path = request.path;
-        let path_buf = PathBuf::from(path);
-
-        // Validate path exists
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
 
         // Use concurrency lock for this directory
         let lock = self.context.get_index_lock(&path_buf).await;
@@ -1782,15 +1748,8 @@ impl CkMcpServer {
     ) -> Result<(String, Value), ErrorData> {
         let path = request.path;
         let force = request.force.unwrap_or(false);
-        let path_buf = PathBuf::from(path);
-
-        // Validate path exists
-        if !path_buf.exists() {
-            return Err(ErrorData::invalid_params(
-                format!("Path does not exist: {}", path_buf.display()),
-                None,
-            ));
-        }
+        // Sandbox-enforced: rejects empty/non-existent/outside-roots paths.
+        let path_buf = self.context.resolve_request_path(&path)?;
 
         // Use concurrency lock for this directory
         let lock = self.context.get_index_lock(&path_buf).await;

--- a/ck-cli/tests/mcp_tests.rs
+++ b/ck-cli/tests/mcp_tests.rs
@@ -192,7 +192,11 @@ async fn test_mcp_nonexistent_path() {
     assert!(result.is_err());
 
     if let Err(error) = result {
-        assert!(error.to_string().contains("Path does not exist"));
+        let msg = error.to_string();
+        assert!(
+            msg.contains("does not exist"),
+            "expected 'does not exist' in error, got: {msg}"
+        );
     }
 }
 


### PR DESCRIPTION
## Problem (security: HIGH)

Every MCP tool handler accepted \`request.path\` verbatim:

\`\`\`rust
let path_buf = PathBuf::from(request.path);
\`\`\`

The only validation was an existence check. An agent connected over MCP could ask ck to **index or semantically search any path readable by the host** — \`/etc\`, another user's home, anything. \`McpContext\` stored a \`cwd\` field but nothing in the request pipeline enforced it.

Found via code review (task #9).

## Fix

1. **\`McpContext::allowed_roots: Vec<PathBuf>\`** — canonical roots the MCP server is permitted to touch. Defaults to \`[canonical(cwd)]\`. Operators can extend via \`CK_MCP_ALLOWED_ROOTS\` env var (colon-separated, like \`PATH\`).
2. **\`McpContext::resolve_request_path(raw) -> Result<PathBuf, ErrorData>\`** — parses the raw string, joins relative against cwd, rejects empty / non-existent paths with \`invalid_params\`, **canonicalizes** the result (so symlinks resolve), then **verifies containment** against \`allowed_roots\`.
3. **All 6 tool handlers** (\`semantic\`, \`lexical\`, \`regex\`, \`hybrid\`, \`index_status\`, \`reindex\`) replace \`PathBuf::from(path)\` + ad-hoc existence check with one \`resolve_request_path\` call.

## Tests (all 7 pass under \`--no-default-features\`)

- \`accepts_existing_path_inside_root\`
- \`accepts_relative_path_inside_root\`
- \`rejects_absolute_path_outside_root\` ← the primary escape vector
- \`rejects_dot_dot_escape\` ← \`../..\` traversal
- \`rejects_symlink_pointing_outside_root\` (unix-gated) ← symlink trickery
- \`rejects_empty_path\`
- \`rejects_nonexistent_path\`

## Notes

- Independent of PR #111 — touches \`ck-cli/src/mcp/*\` only.
- Future work: extend allowed_roots config to a config file or per-tool overrides if operators need finer control. Env var is the minimum-viable knob.
- Operator-visible behavior change: requests for paths outside the sandbox now fail with a clear \`invalid_params\` error mentioning \`CK_MCP_ALLOWED_ROOTS\`, instead of silently scanning them.

## Test plan

- [x] \`cargo test -p ck-search --no-default-features --lib sandbox_tests\` — 7/7 pass
- [x] \`cargo clippy -p ck-search --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --all --check\` — clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)