### PR TITLE
fix(deps): pin ort to =2.0.0-rc.11 so cargo install doesn't break

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,7 +72,13 @@ base64 = "0.22"
 sha2 = "0.10"
 hf-hub = { version = "0.4.3", default-features = false, features = ["ureq"] }
 tokenizers = "0.20.1"
-ort = { version = "2.0.0-rc.11", default-features = false, features = ["download-binaries", "tls-native", "ndarray", "std"] }
+# Pinned exactly to rc.11. ort 2.0.0-rc.12 made SessionOptionsPointer
+# !Sync, which removes Send+Sync from ort::Error<SessionBuilder> and
+# breaks `?`-conversion into anyhow::Error throughout ck-embed::mixedbread.
+# Without the `=` pin, a fresh `cargo install ck-search` (no --locked)
+# upgrades to rc.12 and 36 errors cascade. See:
+# https://github.com/BeaconBay/ck/pull/<TODO> for follow-up to evaluate rc.12.
+ort = { version = "=2.0.0-rc.11", default-features = false, features = ["download-binaries", "tls-native", "ndarray", "std"] }
 once_cell = "1.19"
 ndarray = { version = "0.17", default-features = false, features = ["std"] }
 num_cpus = "1.16"


### PR DESCRIPTION
## Problem (severity: HIGH, user-facing)

@gianpaj hit this trying \`cargo install ck-search\` on 0.7.6:

\`\`\`
error[E0277]: \`?\` couldn't convert the error: \`NonNull<OrtSessionOptions>: Sync\` is not satisfied
   --> ck-embed-0.7.6/src/mixedbread.rs:50:69
\`\`\`

36 errors cascade out of \`ck-embed::mixedbread\`.

## Root cause

\`cargo install ck-search\` **without \`--locked\`** ignores the published \`Cargo.lock\` and re-solves deps from scratch. Our workspace had \`ort = "2.0.0-rc.11"\` which is a caret range — cargo picks the latest matching release, which is now \`2.0.0-rc.12\`.

\`ort 2.0.0-rc.12\` changed \`SessionOptionsPointer\` to wrap a \`NonNull<OrtSessionOptions>\` which is \`!Sync\`. That removes \`Send + Sync\` from \`SessionBuilder\`, which propagates to \`ort::Error<SessionBuilder>\`, which means it can no longer be \`?\`-converted into \`anyhow::Error\` (which requires both).

Users hitting this can work around with \`cargo install ck-search --locked\`, but that's a footgun we shouldn't make them know about.

## Fix

Pin to \`=2.0.0-rc.11\` exact. \`cargo install\` (with or without \`--locked\`) is forced to use the version we tested against. Cargo.lock unchanged.

## Follow-up

Evaluate upgrade to \`ort 2.0.0-rc.12\` properly in a separate PR — likely needs \`ck-embed::mixedbread\` to map ort errors via \`.map_err(anyhow::Error::msg)\` or similar, since the \`From\` blanket impl no longer fires.

## Test plan

- [x] \`cargo check --workspace\` — passes
- [x] \`cargo update -p ort --dry-run\` — locks 0 packages (pin enforced)
- [x] \`cargo fmt --all --check\` — clean
- [ ] CI green
- [ ] After merge: cut 0.7.7 hotfix

🤖 Generated with [Claude Code](https://claude.com/claude-code)