### PR TITLE
feat(release): publish ck as @beaconbay/ck-search on npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -345,9 +345,65 @@ jobs:
 
           echo "All crates published successfully!"
 
+  publish-npm:
+    name: Publish to npm (@beaconbay/ck-search)
+    needs: build-release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Sync package.json version from Cargo.toml + tag
+        run: |
+          set -euo pipefail
+
+          if [ -z "${NPM_TOKEN_PRESENT:-}" ] && [ -z "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "::error::NPM_TOKEN repo secret is not set"
+            exit 1
+          fi
+
+          cargo_version=$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
+          tag_version="${{ github.ref_name }}"
+
+          echo "Cargo.toml version: $cargo_version"
+          echo "Git tag:           $tag_version"
+
+          if [ "$cargo_version" != "$tag_version" ]; then
+            echo "::error::Cargo.toml version ($cargo_version) doesn't match git tag ($tag_version)"
+            exit 1
+          fi
+
+          # Stamp package.json from the workspace version. Source of truth
+          # is Cargo.toml + git tag — package.json's committed version is
+          # informational, never the gate.
+          npm version "$cargo_version" --no-git-tag-version --allow-same-version
+          echo "package.json synced to $cargo_version"
+
+      - name: Check if already published
+        id: check
+        run: |
+          if npm view "@beaconbay/ck-search@${{ github.ref_name }}" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "v${{ github.ref_name }} already on npm, skipping"
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish to npm
+        if: steps.check.outputs.already == 'false'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+
   finalize-release:
     name: Finalize GitHub Release
-    needs: [build-release, publish-crates]
+    needs: [build-release, publish-crates, publish-npm]
     runs-on: ubuntu-latest
     if: always() && needs.build-release.result == 'success'
     steps:

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ docs-site/.vitepress/.temp
 # Claude Code local settings
 .claude/
 docs/tasks
+
+# npm distribution (root) — produced by scripts/install.js
+dist/
+node_modules/
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,21 @@
+# Exclude everything by default
+*
+
+# Include only what we need for npm distribution
+!cli/
+!scripts/
+!package.json
+!README.md
+!LICENSE-MIT
+!LICENSE-APACHE
+
+# Don't include build artifacts or git stuff
+.git
+.github
+target/
+examples/
+tests/
+*.rs
+Cargo.*
+.gitignore
+.ckignore

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,24 @@ All nine crates ship in lockstep. To bump from OLD to NEW:
 That's it. Individual crate `Cargo.toml` files inherit the workspace version
 via `version.workspace = true` and depend on siblings via `{ workspace = true }`.
 
+**You do NOT need to bump `package.json`.** The `publish-npm` job in
+`release.yml` reads `Cargo.toml`'s `[workspace.package] version` at publish
+time and stamps `package.json` to match before `npm publish`. The committed
+`package.json` version is informational — only the tag + Cargo.toml are
+the gate.
+
+### What `release.yml` does on tag push
+
+When tag `X.Y.Z` is pushed:
+
+1. **Create GitHub release** (draft) and verify tag matches `Cargo.toml`
+2. **Build binaries** for 5 targets (linux x86_64, macos x86_64+arm64, windows x86_64+arm64), upload as `.tar.gz`/`.zip` assets
+3. **Publish 9 crates to crates.io** in dep order, with retry-on-"already-published" and verify-via-API (User-Agent required)
+4. **Publish to npm as `@beaconbay/ck-search`** — postinstall script downloads the platform binary from the GitHub release at user install time
+5. **Finalize GitHub release** (out of draft)
+
+Required repo secrets: `CARGO_REGISTRY_TOKEN`, `NPM_TOKEN`, `GITHUB_TOKEN` (auto).
+
 ### CHANGELOG.md Format
 
 Always update CHANGELOG.md with new releases. Follow this structure:

--- a/cli/ck.js
+++ b/cli/ck.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+const { spawn } = require('node:child_process');
+const { join } = require('node:path');
+const { existsSync } = require('node:fs');
+
+const isWindows = process.platform === 'win32';
+const exe = isWindows ? '.exe' : '';
+const localPath = join(__dirname, '..', 'dist', 'bin', `ck${exe}`);
+
+// Try local installation first, fallback to global PATH
+const bin = existsSync(localPath) ? localPath : 'ck';
+
+const child = spawn(bin, process.argv.slice(2), {
+  stdio: 'inherit',
+  shell: isWindows
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+  } else {
+    process.exit(code ?? 1);
+  }
+});

--- a/docs/npm-distribution.md
+++ b/docs/npm-distribution.md
@@ -1,0 +1,156 @@
+# NPM Distribution Guide
+
+This document explains how ck is distributed via npm and how to publish new versions.
+
+## Overview
+
+ck is a Rust binary distributed via npm using a thin Node.js wrapper. This allows JavaScript/TypeScript developers to install ck without needing Rust installed locally.
+
+## How It Works
+
+1. **Installation**: When users run `npm install -g @beaconbay/ck-search`:
+   - The `scripts/install.js` script runs
+   - It detects the user's platform (OS + architecture)
+   - Downloads prebuilt binary from GitHub releases
+   - Falls back to building from source if Cargo is available
+
+2. **Execution**: When users run `ck`:
+   - The `cli/ck.js` wrapper spawns the actual Rust binary
+   - All arguments are passed through unchanged
+   - stdio is inherited for seamless CLI experience
+
+## Supported Platforms
+
+Prebuilt binaries are available for:
+- **Linux**: x86_64 (glibc)
+- **macOS**: x86_64 (Intel), aarch64 (Apple Silicon)
+- **Windows**: x86_64
+
+For other platforms, users need Cargo installed to build from source.
+
+## Publishing to npm
+
+### Prerequisites
+
+1. npm account with access to `@beaconbay` scope
+2. Logged in via `npm login`
+3. GitHub release with binaries already published
+
+### Steps
+
+1. **Ensure version matches**:
+   ```bash
+   # package.json version must match Cargo.toml workspace version
+   # This happens automatically during release
+   ```
+
+2. **Test locally**:
+   ```bash
+   # Build and test the package locally
+   npm pack
+   npm install -g beaconbay-ck-search-0.7.0.tgz
+   ck --version
+   npm uninstall -g @beaconbay/ck-search
+   ```
+
+3. **Publish to npm**:
+   ```bash
+   npm publish --access public
+   ```
+
+### Automation (Future)
+
+Consider adding to `.github/workflows/release.yml`:
+
+```yaml
+- name: Publish to npm
+  if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+  env:
+    NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+  run: |
+    echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > ~/.npmrc
+    npm publish --access public
+```
+
+## Testing Locally
+
+### Test installation from GitHub release:
+
+```bash
+# Clear any previous dist
+rm -rf dist/
+
+# Run install script manually
+node scripts/install.js
+
+# Test the binary
+node cli/ck.js --version
+```
+
+### Test fallback to source build:
+
+```bash
+# Clear dist and temporarily rename a release to force fallback
+rm -rf dist/
+# Edit package.json to invalid version temporarily
+node scripts/install.js
+```
+
+## Troubleshooting
+
+### "No prebuilt binary available"
+
+- Check that GitHub release exists for the version in package.json
+- Verify asset names match pattern: `ck-{version}-{target}.{tar.gz|zip}`
+- Ensure download URL is publicly accessible
+
+### "Binary not found after installation"
+
+- Check that binary is executable: `ls -la dist/bin/ck`
+- On Unix, ensure permissions: `chmod +x dist/bin/ck`
+- On Windows, ensure .exe extension is correct
+
+### "cargo build failed"
+
+- User needs Rust installed: https://www.rust-lang.org/tools/install
+- Or use a platform with prebuilt binaries
+
+## File Structure
+
+```
+ck/
+├── package.json          # npm package metadata
+├── cli/
+│   └── ck.js            # Thin wrapper that spawns binary
+├── scripts/
+│   ├── install.js       # Download or build binary
+│   └── test.js          # Smoke test after install
+├── dist/                # Created during install (gitignored)
+│   ├── bin/
+│   │   └── ck          # The actual Rust binary
+│   └── tmp/            # Download cache
+└── .npmignore          # What to exclude from npm package
+```
+
+## Version Management
+
+**Important**: Keep versions in sync:
+- `package.json` version
+- `Cargo.toml` workspace version
+- Git tag
+
+The release workflow should handle this automatically, but always verify before publishing.
+
+## npm vs Cargo
+
+Users can install via either:
+
+```bash
+# Via cargo (Rust developers)
+cargo install ck-search
+
+# Via npm (JavaScript/TypeScript developers)
+npm install -g @beaconbay/ck-search
+```
+
+Both install the same binary, just different distribution channels.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,68 @@
+{
+  "name": "@beaconbay/ck-search",
+  "version": "0.7.7",
+  "description": "Semantic code search - grep that understands what you're looking for. Find code by meaning, not just keywords. Powered by AI embeddings with tree-sitter AST parsing.",
+  "license": "MIT OR Apache-2.0",
+  "author": {
+    "name": "Mike Renwick",
+    "url": "https://github.com/BeaconBay"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/BeaconBay/ck.git"
+  },
+  "bugs": {
+    "url": "https://github.com/BeaconBay/ck/issues"
+  },
+  "homepage": "https://github.com/BeaconBay/ck#readme",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/BeaconBay"
+  },
+  "bin": {
+    "ck": "cli/ck.js"
+  },
+  "scripts": {
+    "install": "node scripts/install.js",
+    "test": "node scripts/test.js"
+  },
+  "engines": {
+    "node": ">=16"
+  },
+  "files": [
+    "cli/",
+    "scripts/",
+    "dist/",
+    "LICENSE-MIT",
+    "LICENSE-APACHE",
+    "README.md"
+  ],
+  "keywords": [
+    "code-search",
+    "semantic-search",
+    "search",
+    "grep",
+    "ripgrep",
+    "code",
+    "ast",
+    "tree-sitter",
+    "cli",
+    "rust",
+    "embeddings",
+    "ai",
+    "ml",
+    "vector-search",
+    "developer-tools",
+    "devtools",
+    "code-analysis",
+    "refactoring",
+    "mcp",
+    "claude"
+  ],
+  "dependencies": {
+    "tar": "^6.2.1"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,233 @@
+#!/usr/bin/env node
+/*
+ * npm install script for ck-search
+ *
+ * Strategy:
+ * 1. Try to download prebuilt binary from GitHub releases
+ * 2. If that fails and Cargo is available, build from source
+ * 3. If neither works, fail with helpful error message
+ */
+
+const { spawnSync } = require('node:child_process');
+const { existsSync, mkdirSync, copyFileSync, chmodSync, createWriteStream } = require('node:fs');
+const { join } = require('node:path');
+const https = require('node:https');
+const http = require('node:http');
+const os = require('node:os');
+const tar = require('tar');
+
+function log(message, step) {
+  const prefix = step ? `[@beaconbay/ck-search] [${step}]` : '@beaconbay/ck-search:';
+  console.log(`${prefix} ${message}`);
+}
+
+function logStep(step, total, message) {
+  console.log(`\n[@beaconbay/ck-search] [${step}/${total}] ${message}`);
+}
+
+function fail(message) {
+  console.error(`\n[@beaconbay/ck-search] ❌ ERROR: ${message}`);
+  process.exit(1);
+}
+
+function hasCargo() {
+  try {
+    const result = spawnSync('cargo', ['--version'], { stdio: 'ignore' });
+    return result.status === 0;
+  } catch {
+    return false;
+  }
+}
+
+function buildFromSource() {
+  logStep(2, 2, '🔨 Building from source with cargo...');
+  log('This may take a few minutes...', '   ');
+
+  const args = ['build', '--release', '--locked', '--package', 'ck-search'];
+  const result = spawnSync('cargo', args, { stdio: 'inherit' });
+
+  if (result.status !== 0) {
+    fail('cargo build failed. Please ensure Rust and Cargo are installed: https://www.rust-lang.org/tools/install');
+  }
+
+  log('Copying binary to dist/bin/...', '   ');
+  const isWindows = process.platform === 'win32';
+  const exe = isWindows ? '.exe' : '';
+  const builtBinary = join(__dirname, '..', 'target', 'release', `ck${exe}`);
+
+  if (!existsSync(builtBinary)) {
+    fail(`Build succeeded but binary not found at ${builtBinary}`);
+  }
+
+  const destDir = join(__dirname, '..', 'dist', 'bin');
+  mkdirSync(destDir, { recursive: true });
+
+  const dest = join(destDir, `ck${exe}`);
+  copyFileSync(builtBinary, dest);
+
+  try {
+    chmodSync(dest, 0o755);
+  } catch (e) {
+    // Windows doesn't support chmod, that's okay
+  }
+
+  console.log(`\n[@beaconbay/ck-search] ✅ Built from source successfully!`);
+}
+
+function detectTargetTriple() {
+  const platform = os.platform();
+  const arch = os.arch();
+
+  // Map Node.js platform/arch to Rust target triples
+  const targetMap = {
+    'linux-x64': 'x86_64-unknown-linux-gnu',
+    'darwin-x64': 'x86_64-apple-darwin',
+    'darwin-arm64': 'aarch64-apple-darwin',
+    'win32-x64': 'x86_64-pc-windows-msvc',
+    'win32-arm64': 'aarch64-pc-windows-msvc',
+  };
+
+  const key = `${platform}-${arch}`;
+  return targetMap[key] || null;
+}
+
+function download(url, destPath) {
+  return new Promise((resolve, reject) => {
+    const client = url.startsWith('https:') ? https : http;
+
+    client.get(url, (res) => {
+      // Handle redirects
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return resolve(download(res.headers.location, destPath));
+      }
+
+      if (res.statusCode !== 200) {
+        return reject(new Error(`HTTP ${res.statusCode}: ${res.statusMessage}`));
+      }
+
+      const file = createWriteStream(destPath);
+      res.pipe(file);
+
+      file.on('finish', () => {
+        file.close();
+        resolve();
+      });
+
+      file.on('error', (err) => {
+        file.close();
+        reject(err);
+      });
+    }).on('error', reject);
+  });
+}
+
+async function tryDownloadPrebuilt() {
+  logStep(1, 2, '📦 Attempting to download prebuilt binary...');
+
+  const version = require('../package.json').version;
+  const target = detectTargetTriple();
+
+  if (!target) {
+    log(`Platform ${os.platform()}-${os.arch()} not supported for prebuilt binaries`, '   ');
+    return false;
+  }
+
+  log(`Detected platform: ${target}`, '   ');
+
+  const isWindows = process.platform === 'win32';
+  const assetExt = isWindows ? 'zip' : 'tar.gz';
+  const assetName = `ck-${version}-${target}.${assetExt}`;
+  const downloadUrl = `https://github.com/BeaconBay/ck/releases/download/${version}/${assetName}`;
+
+  const tmpDir = join(__dirname, '..', 'dist', 'tmp');
+  const distBin = join(__dirname, '..', 'dist', 'bin');
+  mkdirSync(tmpDir, { recursive: true });
+  mkdirSync(distBin, { recursive: true });
+
+  const archivePath = join(tmpDir, assetName);
+
+  try {
+    log(`Downloading from GitHub releases...`, '   ');
+    log(`URL: ${downloadUrl}`, '   ');
+    await download(downloadUrl, archivePath);
+    log(`✓ Downloaded ${assetName}`, '   ');
+  } catch (e) {
+    log(`⚠ Prebuilt download failed: ${e.message}`, '   ');
+    return false;
+  }
+
+  try {
+    log('Extracting archive...', '   ');
+    if (isWindows) {
+      // Use built-in unzip on Windows
+      const result = spawnSync('tar', ['-xf', archivePath, '-C', distBin], {
+        stdio: 'pipe',
+        shell: true
+      });
+      if (result.status !== 0) {
+        throw new Error('Failed to extract zip archive');
+      }
+    } else {
+      // Use tar for Unix systems
+      await tar.x({
+        file: archivePath,
+        cwd: distBin,
+      });
+    }
+
+    // Ensure executable permissions
+    const exe = isWindows ? '.exe' : '';
+    const binaryPath = join(distBin, `ck${exe}`);
+
+    try {
+      chmodSync(binaryPath, 0o755);
+    } catch (e) {
+      // Windows doesn't need chmod
+    }
+
+    log('✓ Extracted successfully', '   ');
+    console.log(`\n[@beaconbay/ck-search] ✅ Prebuilt binary installed!`);
+    return true;
+  } catch (e) {
+    log(`⚠ Failed to extract prebuilt binary: ${e.message}`, '   ');
+    return false;
+  }
+}
+
+async function main() {
+  console.log('\n╭──────────────────────────────────────────────╮');
+  console.log('│  @beaconbay/ck-search installation           │');
+  console.log('╰──────────────────────────────────────────────╯\n');
+
+  // Skip install in CI environments where ck might already be installed globally
+  if (process.env.CI && process.env.SKIP_CK_INSTALL) {
+    log('Skipping installation in CI (SKIP_CK_INSTALL=true)');
+    return;
+  }
+
+  // Try prebuilt binary first
+  const downloaded = await tryDownloadPrebuilt();
+  if (downloaded) {
+    console.log('\n✨ Installation complete! Try: ck --version\n');
+    return;
+  }
+
+  // Fallback to building from source
+  console.log('\n[@beaconbay/ck-search] ℹ️  Prebuilt binary not available, falling back to source build...');
+
+  if (!hasCargo()) {
+    fail(
+      'No prebuilt binary available for your platform and Cargo not found.\n' +
+      'Please either:\n' +
+      '  1. Install Rust: https://www.rust-lang.org/tools/install\n' +
+      '  2. Or use a platform with prebuilt binaries (Linux x64, macOS x64/arm64, Windows x64)'
+    );
+  }
+
+  buildFromSource();
+  console.log('\n✨ Installation complete! Try: ck --version\n');
+}
+
+main().catch((e) => {
+  fail(e.message);
+});

--- a/scripts/test.js
+++ b/scripts/test.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+/*
+ * Simple smoke test to verify ck binary works after npm install
+ */
+
+const { spawnSync } = require('node:child_process');
+const { join } = require('node:path');
+const { existsSync } = require('node:fs');
+
+const isWindows = process.platform === 'win32';
+const exe = isWindows ? '.exe' : '';
+const binaryPath = join(__dirname, '..', 'dist', 'bin', `ck${exe}`);
+
+if (!existsSync(binaryPath)) {
+  console.error('ERROR: ck binary not found at', binaryPath);
+  process.exit(1);
+}
+
+// Test that binary runs and shows version
+const result = spawnSync(binaryPath, ['--version'], {
+  encoding: 'utf8',
+  stdio: 'pipe'
+});
+
+if (result.status !== 0) {
+  console.error('ERROR: ck --version failed');
+  console.error('stdout:', result.stdout);
+  console.error('stderr:', result.stderr);
+  process.exit(1);
+}
+
+console.log('✓ ck binary works:', result.stdout.trim());
+console.log('✓ npm package installation successful');


### PR DESCRIPTION
## Summary

Adds the second distribution channel asked for in the original release plan: \`npm install -g @beaconbay/ck-search\` for users who don't have Rust installed.

## How it works

- **\`package.json\`** declares \`@beaconbay/ck-search\` with a postinstall script and the \`ck\` bin entry pointing to a thin JS wrapper.
- **\`scripts/install.js\`** runs on \`npm install\`: detects platform, builds the matching GitHub release asset URL (\`ck-X.Y.Z-<target>.{tar.gz|zip}\`), downloads + extracts into \`dist/bin/\`. Falls back to \`cargo build\` if invoked from a checkout (the published tarball deliberately doesn't ship Rust source, so the fallback is realistic only for local installs).
- **\`cli/ck.js\`** is a thin \`spawn\` wrapper that runs \`dist/bin/ck\` with inherited stdio.
- **\`scripts/test.js\`** is the postinstall smoke test (\`npm test\`).
- **\`.npmignore\`** restricts the published tarball to just \`cli/\`, \`scripts/\`, \`package.json\`, \`README.md\`, \`LICENSE-*\`.

## \`release.yml\` changes

- New \`publish-npm\` job after \`build-release\`. **Version is single-source-of-truth**: the workspace \`Cargo.toml\` version + the git tag are the gate. The job runs \`npm version --no-git-tag-version\` to stamp \`package.json\` at publish time — **maintainers never have to bump \`package.json\` manually**.
- Idempotent (skips publish if \`@beaconbay/ck-search@X.Y.Z\` already exists on npm).
- \`finalize-release\` now waits on both \`publish-crates\` and \`publish-npm\`.

## New repo secret required

- \`NPM_TOKEN\` — npm automation token with publish access to the \`@beaconbay\` scope. Without it the job fails fast with \`::error::NPM_TOKEN repo secret is not set\` (same fail-loud pattern as \`CARGO_REGISTRY_TOKEN\` in PR #116).

## Validated locally against the live 0.7.7 release

- \`npm pack --dry-run\` → clean 15 kB tarball, 7 files (\`cli/ck.js\`, \`scripts/install.js\`, \`scripts/test.js\`, \`package.json\`, \`README.md\`, \`LICENSE-MIT\`, \`LICENSE-APACHE\`)
- \`node scripts/install.js\` → correctly detected \`aarch64-apple-darwin\`, downloaded + extracted from GH release
- \`node cli/ck.js --version\` → prints \`ck 0.7.7\`
- \`node scripts/test.js\` → \`✓ ck binary works: ck 0.7.7\`

## Origin

These files are a re-pickup of the abandoned \`feature/npm-distribution\` branch from October 2025 (four commits by @runonthespot — 9b20ae0, cff3623, 5a53b72, 40e3d01). The branch was too far behind \`main\` to rebase cleanly, so I ported the files verbatim onto current \`main\` with these adjustments:

- \`package.json\` version bumped from stale \`0.7.0\` to current \`0.7.7\`
- Removed dead \`\"main\": \"index.js\"\` (no such file exists)
- Workflow rewritten to **auto-stamp package.json version from Cargo.toml** at publish time, rather than requiring both to be hand-kept in sync

## Test plan

- [x] \`npm pack --dry-run\` clean
- [x] \`node -c\` syntax check on all 3 JS files
- [x] Full install flow against live 0.7.7 GH release
- [x] \`cargo fmt --check\` clean
- [ ] CI green on this PR
- [ ] After merge: set \`NPM_TOKEN\` secret, cut 0.7.8, verify first npm publish

## Out of scope (follow-ups)

- The \`buildFromSource\` cargo fallback path in \`install.js\` can never fire from a published npm tarball (Rust source is excluded). Could either remove it or improve the error message to point out it's checkout-only. Left as-is to match the original.
- Linux \`aarch64\` is not currently built by \`release.yml\`; npm install on that target falls through to the cargo fallback and fails. Worth adding the target separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)