### PR TITLE
chore(deps): split dependabot grouping + safe bumps from closed #115

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,77 @@
+# Dependabot configuration
+#
+# Goals:
+# - Cargo dependencies in two groups so a single risky major bump can't
+#   block a batch of safe patch bumps from merging (which is what
+#   happened with rmcp 0.6 → 1.4 in #115).
+# - Stay on weekly cadence so we're not drowning in PRs.
+# - npm dev-dep PRs continue to come through (docs-site + ck-vscode).
+
+version: 2
+updates:
+  # Cargo (workspace) — split into safe patch/minor bumps vs flagged
+  # crates that need manual API migration when they go major.
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-safe:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+        exclude-patterns:
+          # rmcp's 0.x → 1.x is a hand-migration; keep it in its own PR
+          # so it can't ride along on a safe-patches grouping.
+          - "rmcp"
+          - "rmcp-macros"
+          # ort prereleases (-rc.X) need careful evaluation per bump;
+          # we pin to =2.0.0-rc.11 deliberately in Cargo.toml.
+          - "ort"
+          - "ort-sys"
+      cargo-flagged:
+        applies-to: version-updates
+        patterns:
+          - "rmcp"
+          - "rmcp-macros"
+          - "ort"
+          - "ort-sys"
+
+  # npm — VSCode extension dev deps
+  - package-ecosystem: npm
+    directory: /ck-vscode
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      npm-dev:
+        update-types:
+          - patch
+          - minor
+
+  # npm — docs site dev deps
+  - package-ecosystem: npm
+    directory: /docs-site
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      docs-dev:
+        update-types:
+          - patch
+          - minor
+
+  # GitHub Actions workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    groups:
+      gha:
+        update-types:
+          - patch
+          - minor
+          - major

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,9 +304,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b35204fbdc0b3f4446b89fc1ac2cf84a8a68971995d0bf2e925ec7cd960f9cb3"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cassowary"
@@ -1099,7 +1099,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1926,9 +1926,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
+checksum = "373f5eceeeab7925e0c1098212f2fbc4d416adec9d35051a6ab251e824c1854a"
 
 [[package]]
 name = "lzma-rust2"
@@ -2262,15 +2262,14 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2303,9 +2302,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2552,9 +2551,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
@@ -2602,9 +2601,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
  "rand_chacha 0.3.1",
@@ -2666,7 +2665,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
 dependencies = [
  "num-traits",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -2951,7 +2950,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2981,9 +2980,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3576,7 +3575,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3630,9 +3629,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -3651,9 +3650,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -3702,7 +3701,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.8.5",
+ "rand 0.8.6",
  "rayon",
  "rayon-cond 0.3.0",
  "regex",


### PR DESCRIPTION
## Summary

Two related pieces of cleanup after closing #115 (which mixed safe patch bumps with an rmcp 0.x→1.x major-version break that doesn't compile).

## 1. Add \`.github/dependabot.yml\`

Repo had no dependabot config — bumps were running on whatever defaults dependabot chose. That meant rmcp's major-version PR got grouped with 7 safe patch bumps; the major-version compile break poisoned the whole group and we had to close it.

New config splits cargo bumps into two groups:

- **\`cargo-safe\`** — patch + minor for everything **except** rmcp and ort. Auto-mergeable in spirit (CI still gates).
- **\`cargo-flagged\`** — rmcp(-macros) and ort(-sys) only. Each gets its own PR; a major bump there is a hand migration.

Also configures the existing npm groupings (ck-vscode, docs-site) and a github-actions group.

## 2. Cherry-pick the 7 safe bumps from #115

Cargo.lock-only update via \`cargo update -p ...\`. None of these need a Cargo.toml change — all version constraints in \`[workspace.dependencies]\` were already permissive enough.

| crate | before | after |
|---|---|---|
| **openssl** | 0.10.75 | 0.10.80 (fixes \`cipher_update_inplace\` buffer overflow) |
| **openssl-sys** | 0.9.111 | 0.9.116 |
| bytes | 1.11.0 | 1.11.1 |
| lz4_flex | 0.11.5 | 0.11.6 |
| quinn-proto | 0.11.13 | 0.11.14 |
| rand | 0.8.5 | 0.8.6 |
| rustls-webpki | 0.103.9 | 0.103.13 |
| time | 0.3.46 | 0.3.47 |
| time-macros | 0.2.26 | 0.2.27 |

The openssl bump is the only one with anything beyond a routine patch — it includes a buffer-overflow fix in AES key-wrap-with-padding.

## What this prevents going forward

Once the dependabot.yml lands, the next scheduled cargo run produces:
- One \`cargo-safe\` PR with whatever patch/minor bumps are pending
- A separate PR per rmcp/ort major bump

So #115's pattern (safe bumps held hostage by a hand-migration) doesn't recur.

## Test plan

- [x] \`cargo check --workspace\` passes against bumped lockfile
- [x] \`cargo fmt --all --check\` clean
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)