### PR TITLE
ci(release): switch npm publish to Trusted Publishing (OIDC) + provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,6 +349,14 @@ jobs:
     name: Publish to npm (@beaconbay/ck-search)
     needs: build-release
     runs-on: ubuntu-latest
+    # Trusted Publishing (OIDC): GitHub mints a short-lived id-token,
+    # npm validates it against the trusted-publisher config on the
+    # @beaconbay/ck-search package. No long-lived NPM_TOKEN secret.
+    # The id-token also signs an SLSA provenance attestation that
+    # ties the published tarball to this exact workflow run + commit.
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -362,11 +370,6 @@ jobs:
       - name: Sync package.json version from Cargo.toml + tag
         run: |
           set -euo pipefail
-
-          if [ -z "${NPM_TOKEN_PRESENT:-}" ] && [ -z "${{ secrets.NPM_TOKEN }}" ]; then
-            echo "::error::NPM_TOKEN repo secret is not set"
-            exit 1
-          fi
 
           cargo_version=$(grep -m1 '^version = ' Cargo.toml | sed 's/.*"\(.*\)".*/\1/')
           tag_version="${{ github.ref_name }}"
@@ -395,11 +398,9 @@ jobs:
             echo "already=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Publish to npm
+      - name: Publish to npm (with provenance)
         if: steps.check.outputs.already == 'false'
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --provenance
 
   finalize-release:
     name: Finalize GitHub Release

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,10 +55,12 @@ When tag `X.Y.Z` is pushed:
 1. **Create GitHub release** (draft) and verify tag matches `Cargo.toml`
 2. **Build binaries** for 5 targets (linux x86_64, macos x86_64+arm64, windows x86_64+arm64), upload as `.tar.gz`/`.zip` assets
 3. **Publish 9 crates to crates.io** in dep order, with retry-on-"already-published" and verify-via-API (User-Agent required)
-4. **Publish to npm as `@beaconbay/ck-search`** — postinstall script downloads the platform binary from the GitHub release at user install time
+4. **Publish to npm as `@beaconbay/ck-search`** — uses npm Trusted Publishing (OIDC); GitHub mints a short-lived id-token, npm validates it against the trusted-publisher config on the package, no long-lived secret. Tarball is published with SLSA provenance attestation (cryptographically tied to this workflow run + commit). The package's postinstall script downloads the platform binary from the GitHub release at user install time.
 5. **Finalize GitHub release** (out of draft)
 
-Required repo secrets: `CARGO_REGISTRY_TOKEN`, `NPM_TOKEN`, `GITHUB_TOKEN` (auto).
+Required repo secrets: `CARGO_REGISTRY_TOKEN`, `GITHUB_TOKEN` (auto).
+npm publish requires NO secret — Trusted Publishing config lives on the npm
+package (Settings → Trusted Publishers).
 
 ### CHANGELOG.md Format
 


### PR DESCRIPTION
## Why

The 0.7.8 release failed \`publish-npm\` with HTTP 403:

\`\`\`
Two-factor authentication or granular access token with bypass 2fa
enabled is required to publish packages.
\`\`\`

The \`NPM_TOKEN\` we'd been given was a classic token without 2FA-bypass. Rather than work around 2FA with a long-lived bypass-2FA token, switching to **Trusted Publishing** (OIDC) which is npm's current recommended path for CI/CD.

## How it works after this

1. GitHub mints a short-lived id-token per release run (\`permissions: id-token: write\`)
2. \`actions/setup-node@v6\` picks it up automatically and passes it to npm
3. npm validates against the trusted-publisher config on the package (one-time setup, done by maintainer)
4. Publish succeeds, and \`--provenance\` emits an SLSA attestation tying the tarball to this commit + workflow run

No NPM_TOKEN secret stored anywhere. Token can't be leaked because there is no token.

## Trusted-publisher config (already done on npm)

> npmjs.com → \`@beaconbay/ck-search\` → Settings → Trusted Publishers
> - Repository owner: BeaconBay
> - Repository name: ck
> - Workflow filename: \`release.yml\`
> - Environment: (none)

## Test plan

- [x] \`cargo fmt --check\` clean
- [ ] CI green on this PR
- [ ] After merge: cut 0.7.9, watch \`publish-npm\` actually publish for the first time

## Follow-up

- We can delete the (now-unused) \`NPM_TOKEN\` repo secret after 0.7.9 ships successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)