### PR TITLE
chore(clippy): apply pedantic auto-fixes (inline format args + method refs)

### DIFF
--- a/ck-chunk/examples/debug_chunks.rs
+++ b/ck-chunk/examples/debug_chunks.rs
@@ -13,8 +13,8 @@ fn estimate_tokens(text: &str) -> usize {
 
 #[allow(dead_code)]
 fn test_file(path: &str, language: Language) {
-    println!("=== Testing {} ===", path);
-    let code = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {}", path));
+    println!("=== Testing {path} ===");
+    let code = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("Failed to read {path}"));
 
     println!("File length: {} characters", code.len());
     println!("Estimated tokens: {}", estimate_tokens(&code));
@@ -44,7 +44,7 @@ fn test_file(path: &str, language: Language) {
         // Show first few lines of the chunk
         let lines: Vec<&str> = chunk.text.lines().take(3).collect();
         for line in lines {
-            println!("  {}", line);
+            println!("  {line}");
         }
         if chunk.text.lines().count() > 3 {
             println!("  ...");
@@ -110,7 +110,7 @@ fn test_striding() {
         );
 
         if token_estimate > config.max_tokens {
-            println!("  ⚠️  Still exceeds limit! ({})", token_estimate);
+            println!("  ⚠️  Still exceeds limit! ({token_estimate})");
         } else {
             println!("  ✅ Within limit");
         }

--- a/ck-chunk/src/lib.rs
+++ b/ck-chunk/src/lib.rs
@@ -159,7 +159,7 @@ impl std::fmt::Display for ParseableLanguage {
 
             ParseableLanguage::Elixir => "elixir",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 
@@ -183,8 +183,7 @@ impl TryFrom<ck_core::Language> for ParseableLanguage {
             ck_core::Language::Elixir => Ok(ParseableLanguage::Elixir),
 
             _ => Err(anyhow::anyhow!(
-                "Language {:?} is not supported for parsing",
-                lang
+                "Language {lang:?} is not supported for parsing"
             )),
         }
     }
@@ -393,7 +392,7 @@ fn chunk_language(text: &str, language: ParseableLanguage) -> Result<Vec<Chunk>>
 
     let tree = parser
         .parse(text, None)
-        .ok_or_else(|| anyhow::anyhow!("Failed to parse {} code", language))?;
+        .ok_or_else(|| anyhow::anyhow!("Failed to parse {language} code"))?;
 
     let mut chunks = match query_chunker::chunk_with_queries(language, ts_language, &tree, text)? {
         Some(query_chunks) if !query_chunks.is_empty() => query_chunks,
@@ -593,7 +592,7 @@ fn merge_haskell_functions(chunks: Vec<Chunk>, source: &str) -> Vec<Chunk> {
                 .split("::")
                 .next()
                 .and_then(|s| s.split_whitespace().next())
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
         } else {
             extract_haskell_function_name(&chunk.text)
         };
@@ -631,7 +630,7 @@ fn merge_haskell_functions(chunks: Vec<Chunk>, source: &str) -> Vec<Chunk> {
                     .split("::")
                     .next()
                     .and_then(|s| s.split_whitespace().next())
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
             } else {
                 extract_haskell_function_name(&next_chunk.text)
             };
@@ -1085,7 +1084,7 @@ fn segments_to_strings(segments: &[TriviaSegment], source: &str) -> Vec<String> 
     for segment in segments {
         if let Some(text) = source
             .get(segment.start_byte..segment.end_byte)
-            .map(|s| s.to_string())
+            .map(std::string::ToString::to_string)
         {
             result.push(text);
         }
@@ -1213,7 +1212,7 @@ fn first_word_of_node(node: tree_sitter::Node<'_>, source: &str) -> Option<Strin
 fn text_for_node(node: tree_sitter::Node<'_>, source: &str) -> Option<String> {
     node.utf8_text(source.as_bytes())
         .ok()
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
 }
 
 fn only_whitespace_between(source: &str, start: usize, end: usize) -> bool {
@@ -1221,7 +1220,7 @@ fn only_whitespace_between(source: &str, start: usize, end: usize) -> bool {
         return true;
     }
 
-    source[start..end].chars().all(|c| c.is_whitespace())
+    source[start..end].chars().all(char::is_whitespace)
 }
 
 fn adjust_chunk_type_for_context(
@@ -1543,7 +1542,7 @@ mod tests {
     fn test_chunk_generic_large_file_performance() {
         // Create a large text to ensure O(n) performance
         let lines: Vec<String> = (0..1000)
-            .map(|i| format!("Line {}: Some content here", i))
+            .map(|i| format!("Line {i}: Some content here"))
             .collect();
         let text = lines.join("\n");
 
@@ -1554,8 +1553,7 @@ mod tests {
         // Should complete quickly even for 1000 lines
         assert!(
             duration.as_millis() < 100,
-            "Chunking took too long: {:?}",
-            duration
+            "Chunking took too long: {duration:?}"
         );
         assert!(!chunks.is_empty());
 
@@ -1568,7 +1566,7 @@ mod tests {
 
     #[test]
     fn test_chunk_rust() {
-        let rust_code = r#"
+        let rust_code = r"
 pub struct Calculator {
     memory: f64,
 }
@@ -1590,7 +1588,7 @@ fn main() {
 pub mod utils {
     pub fn helper() {}
 }
-"#;
+";
 
         let chunks = chunk_language(rust_code, ParseableLanguage::Rust).unwrap();
         assert!(!chunks.is_empty());
@@ -1604,10 +1602,10 @@ pub mod utils {
 
     #[test]
     fn test_rust_doc_comments_attached() {
-        let rust_code = r#"
+        let rust_code = r"
 /// Doc comment
 pub struct Foo {}
-"#;
+";
         let chunks = chunk_language(rust_code, ParseableLanguage::Rust).unwrap();
         let struct_chunk = chunks
             .iter()
@@ -1621,7 +1619,7 @@ pub struct Foo {}
 
     #[test]
     fn test_rust_query_matches_legacy() {
-        let source = r#"
+        let source = r"
             mod sample {
                 struct Thing;
 
@@ -1632,14 +1630,14 @@ pub struct Foo {}
             }
 
             fn util() {}
-        "#;
+        ";
 
         assert_query_parity(ParseableLanguage::Rust, source);
     }
 
     #[test]
     fn test_python_query_matches_legacy() {
-        let source = r#"
+        let source = r"
 class Example:
     @classmethod
     def build(cls):
@@ -1652,7 +1650,7 @@ def helper():
 
 async def async_helper():
     return 2
-"#;
+";
 
         assert_query_parity(ParseableLanguage::Python, source);
     }
@@ -1760,7 +1758,7 @@ func main() {
     #[test]
     #[ignore] // TODO: Update test to match query-based chunking behavior
     fn test_chunk_typescript_arrow_context() {
-        let ts_code = r#"
+        let ts_code = r"
 // Utility function
 export const util = () => {
     // comment about util
@@ -1778,7 +1776,7 @@ export class Example {
 }
 
 const compute = (x: number) => x * 2;
-"#;
+";
 
         let chunks = chunk_language(ts_code, ParseableLanguage::TypeScript).unwrap();
 
@@ -1837,7 +1835,7 @@ const compute = (x: number) => x * 2;
     #[test]
     #[ignore]
     fn test_typescript_query_matches_legacy() {
-        let source = r#"
+        let source = r"
 export const util = () => {
     return 42;
 };
@@ -1849,7 +1847,7 @@ export class Example {
 }
 
 const compute = (x: number) => x * 2;
-"#;
+";
 
         assert_query_parity(ParseableLanguage::TypeScript, source);
     }
@@ -1928,7 +1926,7 @@ shapeDescription (Square s) = "square of side " ++ show s
 
     #[test]
     fn test_csharp_query_matches_legacy() {
-        let source = r#"
+        let source = r"
 namespace Calculator;
 
 public interface ICalculator 
@@ -1951,7 +1949,7 @@ public class Calculator
         return x + y;
     }
 }
-"#;
+";
 
         assert_query_parity(ParseableLanguage::CSharp, source);
     }
@@ -2071,20 +2069,17 @@ test "multiply function" {
 
         assert!(
             class_count >= 5,
-            "Expected at least 5 Class chunks (struct, enum, union, opaque, error set), found {}",
-            class_count
+            "Expected at least 5 Class chunks (struct, enum, union, opaque, error set), found {class_count}"
         );
 
         assert!(
             function_count >= 3,
-            "Expected at least 3 functions (multiply, divide, main), found {}",
-            function_count
+            "Expected at least 3 functions (multiply, divide, main), found {function_count}"
         );
 
         assert!(
             module_count >= 4,
-            "Expected at least 4 module-type chunks (const std, comptime, 2 tests), found {}",
-            module_count
+            "Expected at least 4 module-type chunks (const std, comptime, 2 tests), found {module_count}"
         );
 
         assert!(
@@ -2103,7 +2098,7 @@ test "multiply function" {
 
     #[test]
     fn test_chunk_csharp() {
-        let csharp_code = r#"
+        let csharp_code = r"
 namespace Calculator;
 
 public interface ICalculator 
@@ -2131,7 +2126,7 @@ public class Calculator
         var calc = new Calculator();
     }
 }
-"#;
+";
 
         let chunks = chunk_language(csharp_code, ParseableLanguage::CSharp).unwrap();
         assert!(!chunks.is_empty());
@@ -2196,7 +2191,7 @@ public class Calculator
     fn test_strided_chunk_line_calculation() {
         // Regression test for line_end calculation in strided chunks
         // Create a chunk large enough to force striding
-        let long_text = (1..=50).map(|i| format!("This is a longer line {} with more content to ensure token count is high enough", i)).collect::<Vec<_>>().join("\n");
+        let long_text = (1..=50).map(|i| format!("This is a longer line {i} with more content to ensure token count is high enough")).collect::<Vec<_>>().join("\n");
 
         let metadata = ChunkMetadata::from_text(&long_text);
         let chunk = Chunk {
@@ -2220,7 +2215,7 @@ public class Calculator
 
         let result = stride_large_chunk(chunk, &config);
         if let Err(e) = &result {
-            eprintln!("Stride error: {}", e);
+            eprintln!("Stride error: {e}");
         }
         assert!(result.is_ok());
 
@@ -2243,9 +2238,7 @@ public class Calculator
                 // Allow some tolerance for striding logic
                 assert!(
                     calculated_line_span <= line_count + 1,
-                    "Line span {} should not exceed content lines {} by more than 1",
-                    calculated_line_span,
-                    line_count
+                    "Line span {calculated_line_span} should not exceed content lines {line_count} by more than 1"
                 );
             }
         }
@@ -2310,7 +2303,7 @@ function main() {
         ];
 
         for (language, code) in test_cases {
-            eprintln!("\n=== Testing {} ===", language);
+            eprintln!("\n=== Testing {language} ===");
             let chunks = chunk_language(code, language).unwrap();
 
             // Verify all non-whitespace bytes are covered
@@ -2333,7 +2326,7 @@ function main() {
                 .collect();
 
             if !uncovered_non_ws.is_empty() {
-                eprintln!("\n=== UNCOVERED NON-WHITESPACE for {} ===", language);
+                eprintln!("\n=== UNCOVERED NON-WHITESPACE for {language} ===");
                 eprintln!("Total bytes: {}", code.len());
                 eprintln!("Uncovered non-whitespace: {}", uncovered_non_ws.len());
 
@@ -2442,7 +2435,7 @@ function main() {
 
     #[test]
     fn test_haskell_function_chunking() {
-        let haskell_code = r#"
+        let haskell_code = r"
 factorial :: Integer -> Integer
 factorial 0 = 1
 factorial n = n * factorial (n - 1)
@@ -2451,7 +2444,7 @@ fibonacci :: Integer -> Integer
 fibonacci 0 = 0
 fibonacci 1 = 1
 fibonacci n = fibonacci (n - 1) + fibonacci (n - 2)
-"#;
+";
 
         let mut parser = tree_sitter::Parser::new();
         parser
@@ -2601,7 +2594,7 @@ end
 
     #[test]
     fn test_chunk_elixir_genserver() {
-        let elixir_code = r#"
+        let elixir_code = r"
 defmodule MyServer do
   use GenServer
 
@@ -2621,7 +2614,7 @@ defmodule MyServer do
     {:noreply, value}
   end
 end
-"#;
+";
 
         let chunks = chunk_language(elixir_code, ParseableLanguage::Elixir).unwrap();
 
@@ -2650,7 +2643,7 @@ end
 
     #[test]
     fn test_chunk_elixir_macros() {
-        let elixir_code = r#"
+        let elixir_code = r"
 defmodule MyMacros do
   defmacro unless(condition, do: block) do
     quote do
@@ -2662,7 +2655,7 @@ defmodule MyMacros do
     quote do: unquote(x) * 2
   end
 end
-"#;
+";
 
         let chunks = chunk_language(elixir_code, ParseableLanguage::Elixir).unwrap();
 
@@ -2774,7 +2767,7 @@ end
     #[test]
     fn test_chunk_elixir_behavior_spelling() {
         // Test both British and American spellings
-        let elixir_code = r#"
+        let elixir_code = r"
 defmodule BritishModule do
   @behaviour GenServer
 end
@@ -2782,7 +2775,7 @@ end
 defmodule AmericanModule do
   @behavior GenServer
 end
-"#;
+";
 
         let chunks = chunk_language(elixir_code, ParseableLanguage::Elixir).unwrap();
 

--- a/ck-chunk/src/query_chunker.rs
+++ b/ck-chunk/src/query_chunker.rs
@@ -18,7 +18,7 @@ pub(crate) fn chunk_with_queries(
     };
 
     let query = Query::new(&ts_language, &query_source)
-        .with_context(|| format!("Failed to compile query for {}", language))?;
+        .with_context(|| format!("Failed to compile query for {language}"))?;
 
     let capture_names = query.capture_names();
     let mut cursor = QueryCursor::new();
@@ -120,7 +120,7 @@ mod tests {
 
     #[test]
     fn rust_queries_capture_core_constructs() {
-        let source = r#"
+        let source = r"
             mod sample {
                 pub struct Thing;
 
@@ -135,7 +135,7 @@ mod tests {
             trait Runner {
                 fn run(&self);
             }
-        "#;
+        ";
 
         let mut parser = Parser::new();
         let ts_language = tree_sitter_language(ParseableLanguage::Rust).expect("rust language");
@@ -254,7 +254,7 @@ def top_level():
     #[test]
     #[ignore] // TODO: Update test expectations to match actual query behavior
     fn typescript_queries_capture_core_constructs() {
-        let source = r#"
+        let source = r"
 // Utility function
 export const util = () => {
     // comment about util
@@ -272,7 +272,7 @@ export class Example {
 }
 
 const compute = (x: number) => x * 2;
-"#;
+";
 
         let mut parser = Parser::new();
         let ts_language = tree_sitter_language(ParseableLanguage::TypeScript).expect("ts language");
@@ -323,7 +323,7 @@ const compute = (x: number) => x * 2;
 
     #[test]
     fn dart_queries_capture_core_constructs() {
-        let source = r#"
+        let source = r"
 class Helper {
   Helper();
   void help() {}
@@ -336,7 +336,7 @@ enum State { on, off }
 void globalFunc() {}
 
 const int MAX = 100;
-"#;
+";
 
         let mut parser = Parser::new();
         let ts_language = tree_sitter_language(ParseableLanguage::Dart).expect("dart language");

--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -482,10 +482,9 @@ async fn run_index_workflow(
     let (chunk_tokens, overlap_tokens) =
         ck_chunk::get_model_chunk_config(Some(model_config.name.as_str()));
 
-    status.info(&format!("📏 FastEmbed Config: {} token limit", max_tokens));
+    status.info(&format!("📏 FastEmbed Config: {max_tokens} token limit"));
     status.info(&format!(
-        "📄 Chunk Config: {} tokens target, {} token overlap (~20%)",
-        chunk_tokens, overlap_tokens
+        "📄 Chunk Config: {chunk_tokens} tokens target, {overlap_tokens} token overlap (~20%)"
     ));
 
     // Create .ckignore file if it doesn't exist
@@ -549,7 +548,7 @@ async fn run_index_workflow(
 
         let progress_callback = Some(Box::new(move |file_name: &str| {
             let short_name = file_name.split('/').next_back().unwrap_or(file_name);
-            overall_pb_clone.set_message(format!("Processing {}", short_name));
+            overall_pb_clone.set_message(format!("Processing {short_name}"));
             overall_pb_clone.inc(1);
         }) as ck_index::ProgressCallback);
 
@@ -695,7 +694,7 @@ async fn dump_file_chunks(file_path: &PathBuf) -> Result<()> {
 
     // Use the shared live chunking function
     let (lines, chunk_metas) = ck_tui::chunk_file_live(path).map_err(|err| {
-        eprintln!("Error: {}", err);
+        eprintln!("Error: {err}");
         std::process::exit(1);
     })?;
 
@@ -713,7 +712,7 @@ async fn dump_file_chunks(file_path: &PathBuf) -> Result<()> {
     // Print header
     println!("File: {}", file_path.display());
     if let Some(lang) = ck_core::Language::from_path(path) {
-        println!("Language: {}", lang);
+        println!("Language: {lang}");
     }
     println!("Chunks: {}", chunk_metas.len());
 
@@ -722,7 +721,7 @@ async fn dump_file_chunks(file_path: &PathBuf) -> Result<()> {
         .iter()
         .filter(|c| c.chunk_type.as_deref() == Some("text"))
         .count();
-    println!("  - Text chunks: {}", text_chunk_count);
+    println!("  - Text chunks: {text_chunk_count}");
     println!(
         "  - Structural chunks: {}",
         chunk_metas.len() - text_chunk_count
@@ -869,13 +868,13 @@ async fn inspect_file_metadata(file_path: &PathBuf, status: &StatusReporter) -> 
 #[tokio::main]
 async fn main() {
     if let Err(e) = run_main().await {
-        eprintln!("DETAILED ERROR: {:#}", e);
+        eprintln!("DETAILED ERROR: {e:#}");
         eprintln!("DEBUG: Error occurred in main");
 
         // Print the error chain for better debugging
         let mut source = e.source();
         while let Some(err) = source {
-            eprintln!("CAUSED BY: {}", err);
+            eprintln!("CAUSED BY: {err}");
             source = err.source();
         }
 
@@ -979,8 +978,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
 
                 status.success("No rebuild required; index already on requested model");
                 status.info(&format!(
-                    "Use '--switch-model {} --force' to rebuild anyway",
-                    model_name
+                    "Use '--switch-model {model_name} --force' to rebuild anyway"
                 ));
                 return Ok(());
             }
@@ -1206,11 +1204,10 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
                     .unwrap_or(0);
 
                 if alias == model_name {
-                    status.info(&format!("  Model: {} ({} dims)", model_name, dims));
+                    status.info(&format!("  Model: {model_name} ({dims} dims)"));
                 } else {
                     status.info(&format!(
-                        "  Model: {} (alias '{}', {} dims)",
-                        model_name, alias, dims
+                        "  Model: {model_name} (alias '{alias}', {dims} dims)"
                     ));
                 }
             }
@@ -1218,8 +1215,8 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
             if verbose {
                 let size_mb = stats.total_size_bytes as f64 / (1024.0 * 1024.0);
                 let index_size_mb = stats.index_size_bytes as f64 / (1024.0 * 1024.0);
-                status.info(&format!("  Source size: {:.1} MB", size_mb));
-                status.info(&format!("  Index size: {:.1} MB", index_size_mb));
+                status.info(&format!("  Source size: {size_mb:.1} MB"));
+                status.info(&format!("  Index size: {index_size_mb:.1} MB"));
 
                 use std::time::UNIX_EPOCH;
                 if stats.index_created > 0
@@ -1533,7 +1530,7 @@ fn highlight_regex_matches(text: &str, pattern: &str, options: &SearchOptions) -
         }
         Err(e) => {
             // Surface regex compilation error to user
-            eprintln!("Warning: Invalid regex pattern '{}': {}", pattern, e);
+            eprintln!("Warning: Invalid regex pattern '{pattern}': {e}");
             // Return original text without highlighting
             text.to_string()
         }
@@ -1606,11 +1603,8 @@ async fn run_search(
             .map_or("unlimited".to_string(), |k| k.to_string());
         let threshold_info = options
             .threshold
-            .map_or("none".to_string(), |t| format!("{:.1}", t));
-        eprintln!(
-            "ℹ Semantic search: top {} results, threshold ≥{}",
-            topk_info, threshold_info
-        );
+            .map_or("none".to_string(), |t| format!("{t:.1}"));
+        eprintln!("ℹ Semantic search: top {topk_info} results, threshold ≥{threshold_info}");
 
         let resolved_model =
             ck_engine::resolve_model_for_path(&options.path, options.embedding_model.as_deref())?;
@@ -1634,10 +1628,9 @@ async fn run_search(
         let (chunk_tokens, overlap_tokens) =
             ck_chunk::get_model_chunk_config(Some(resolved_model.canonical_name()));
 
-        eprintln!("📏 FastEmbed Config: {} token limit", max_tokens);
+        eprintln!("📏 FastEmbed Config: {max_tokens} token limit");
         eprintln!(
-            "📄 Chunk Config: {} tokens target, {} token overlap (~20%)",
-            chunk_tokens, overlap_tokens
+            "📄 Chunk Config: {chunk_tokens} tokens target, {overlap_tokens} token overlap (~20%)"
         );
     }
 
@@ -1685,7 +1678,7 @@ async fn run_search(
         // Basic progress callback for file-level updates
         let indexing_progress_callback = Some(Box::new(move |file_name: &str| {
             let short_name = file_name.split('/').next_back().unwrap_or(file_name);
-            overall_pb_clone.set_message(format!("Processing {}", short_name));
+            overall_pb_clone.set_message(format!("Processing {short_name}"));
             overall_pb_clone.inc(1);
         }) as ck_engine::IndexingProgressCallback);
 
@@ -1824,7 +1817,7 @@ async fn run_search(
                 );
             } else {
                 // No filename or line number
-                println!("{}{}", score_text, highlighted_preview);
+                println!("{score_text}{highlighted_preview}");
             }
         }
     }

--- a/ck-cli/src/mcp/session.rs
+++ b/ck-cli/src/mcp/session.rs
@@ -267,7 +267,7 @@ impl SessionManager {
         // Validate cursor timestamp (not too old)
         let cursor_age = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .map_err(|e| format!("System time error: {}", e))?
+            .map_err(|e| format!("System time error: {e}"))?
             .as_secs()
             - parsed_cursor.timestamp;
 
@@ -301,14 +301,14 @@ impl SessionManager {
             search_params_hash: search_params_hash.to_string(),
             timestamp: SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .map_err(|e| format!("System time error: {}", e))?
+                .map_err(|e| format!("System time error: {e}"))?
                 .as_secs(),
             version: 1,
             original_page_size,
         };
 
         let cursor_json = serde_json::to_string(&cursor)
-            .map_err(|e| format!("Failed to serialize cursor: {}", e))?;
+            .map_err(|e| format!("Failed to serialize cursor: {e}"))?;
 
         Ok(BASE64.encode(cursor_json.as_bytes()))
     }
@@ -317,13 +317,13 @@ impl SessionManager {
     fn parse_cursor(&self, cursor: &str) -> Result<PaginationCursor, String> {
         let cursor_bytes = BASE64
             .decode(cursor)
-            .map_err(|e| format!("Invalid cursor format: {}", e))?;
+            .map_err(|e| format!("Invalid cursor format: {e}"))?;
 
-        let cursor_json = String::from_utf8(cursor_bytes)
-            .map_err(|e| format!("Invalid cursor encoding: {}", e))?;
+        let cursor_json =
+            String::from_utf8(cursor_bytes).map_err(|e| format!("Invalid cursor encoding: {e}"))?;
 
         let parsed_cursor: PaginationCursor = serde_json::from_str(&cursor_json)
-            .map_err(|e| format!("Invalid cursor structure: {}", e))?;
+            .map_err(|e| format!("Invalid cursor structure: {e}"))?;
 
         // Validate cursor version
         if parsed_cursor.version != 1 {
@@ -474,8 +474,8 @@ mod tests {
     fn create_test_results(count: usize) -> Vec<SearchResult> {
         (0..count)
             .map(|i| SearchResult {
-                file: PathBuf::from(format!("/test/file_{}.rs", i)),
-                preview: format!("Test result {} content", i),
+                file: PathBuf::from(format!("/test/file_{i}.rs")),
+                preview: format!("Test result {i} content"),
                 span: ck_core::Span {
                     byte_start: i * 100,
                     byte_end: (i + 1) * 100,

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -112,7 +112,7 @@ fn resolve_include_patterns(
 
     let expanded = expand_glob_patterns_with_base(base_path, &prepared_patterns, exclude_patterns)
         .map_err(|e| {
-            ErrorData::invalid_params(format!("Failed to expand include patterns: {}", e), None)
+            ErrorData::invalid_params(format!("Failed to expand include patterns: {e}"), None)
         })?;
 
     Ok(build_include_patterns(&expanded))
@@ -525,11 +525,11 @@ impl CkMcpServer {
         search_time_ms: u64,
     ) -> serde_json::Value {
         let results: Vec<serde_json::Value> = page.matches.iter().map(|result| {
-            let match_type = format!("{}_match", mode);
+            let match_type = format!("{mode}_match");
             let mut match_obj = json!({
                 "file": {
                     "path": result.file.to_string_lossy(),
-                    "language": result.lang.as_ref().map(|l| l.to_string()).unwrap_or("unknown".to_string())
+                    "language": result.lang.as_ref().map(std::string::ToString::to_string).unwrap_or("unknown".to_string())
                 },
                 "match": {
                     "span": {
@@ -738,7 +738,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: SemanticSearchRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -782,7 +782,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: RegexSearchRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -821,7 +821,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: LexicalSearchRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -862,7 +862,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: HybridSearchRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -901,7 +901,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: IndexStatusRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -945,7 +945,7 @@ impl CkMcpServer {
                 let arguments = context.arguments.clone().unwrap_or_default();
                 let request: ReindexRequest =
                     serde_json::from_value(serde_json::Value::Object(arguments)).map_err(|e| {
-                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {}", e), None)
+                        rmcp::ErrorData::invalid_params(format!("Invalid parameters: {e}"), None)
                     })?;
 
                 let service: &CkMcpServer = context.service;
@@ -1002,7 +1002,7 @@ impl CkMcpServer {
         } else {
             path_buf
                 .parent()
-                .map(|p| p.to_path_buf())
+                .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from("."))
         };
 
@@ -1198,7 +1198,7 @@ impl CkMcpServer {
 
         let summary_suffix = effective_mode
             .as_ref()
-            .map(|s| format!(" [{}]", s))
+            .map(|s| format!(" [{s}]"))
             .unwrap_or_default();
 
         let summary = format!(
@@ -1234,7 +1234,7 @@ impl CkMcpServer {
         } else {
             path_buf
                 .parent()
-                .map(|p| p.to_path_buf())
+                .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from("."))
         };
 
@@ -1334,7 +1334,7 @@ impl CkMcpServer {
                 .map(|v| v.to_string())
                 .unwrap_or_else(|| "unbounded".to_string()),
             threshold
-                .map(|v| format!("{:.3}", v))
+                .map(|v| format!("{v:.3}"))
                 .unwrap_or_else(|| "n/a".into()),
             current_page
         );
@@ -1361,7 +1361,7 @@ impl CkMcpServer {
         } else {
             path_buf
                 .parent()
-                .map(|p| p.to_path_buf())
+                .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from("."))
         };
 
@@ -1488,7 +1488,7 @@ impl CkMcpServer {
         } else {
             path_buf
                 .parent()
-                .map(|p| p.to_path_buf())
+                .map(std::path::Path::to_path_buf)
                 .unwrap_or_else(|| PathBuf::from("."))
         };
 
@@ -1697,7 +1697,7 @@ impl CkMcpServer {
                 // Fallback: Count files in directory for estimation
                 let file_count = WalkDir::new(&path_buf)
                     .into_iter()
-                    .filter_map(|e| e.ok())
+                    .filter_map(std::result::Result::ok)
                     .filter(|e| e.file_type().is_file())
                     .count();
 
@@ -1717,11 +1717,11 @@ impl CkMcpServer {
             let file_count = index_info
                 .get("total_files")
                 .or_else(|| index_info.get("estimated_file_count"))
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .unwrap_or(0);
             let chunk_count = index_info
                 .get("total_chunks")
-                .and_then(|v| v.as_u64())
+                .and_then(serde_json::Value::as_u64)
                 .unwrap_or(0);
 
             if chunk_count > 0 {
@@ -1850,7 +1850,7 @@ impl CkMcpServer {
             }
             Err(e) => {
                 return Err(ErrorData::internal_error(
-                    format!("Reindexing failed: {}", e),
+                    format!("Reindexing failed: {e}"),
                     None,
                 ));
             }

--- a/ck-cli/src/path_utils.rs
+++ b/ck-cli/src/path_utils.rs
@@ -95,9 +95,9 @@ fn expand_glob_patterns_internal(
 
             if is_simple {
                 let fallback_path = if let Some(base) = base_dir {
-                    base.join(format!("**/{}", pattern))
+                    base.join(format!("**/{pattern}"))
                 } else {
-                    PathBuf::from(format!("**/{}", pattern))
+                    PathBuf::from(format!("**/{pattern}"))
                 };
                 let fallback_str = fallback_path.to_string_lossy().to_string();
                 matched |= run_glob(&fallback_str, &globset, base_dir, &mut expanded)?;
@@ -131,13 +131,13 @@ fn run_glob(
                         push_if_new(expanded, matched_path);
                     }
                     Err(e) => {
-                        eprintln!("Warning: glob error for pattern '{}': {}", pattern, e);
+                        eprintln!("Warning: glob error for pattern '{pattern}': {e}");
                     }
                 }
             }
         }
         Err(e) => {
-            eprintln!("Warning: invalid glob pattern '{}': {}", pattern, e);
+            eprintln!("Warning: invalid glob pattern '{pattern}': {e}");
         }
     }
     Ok(matched)

--- a/ck-cli/src/progress.rs
+++ b/ck-cli/src/progress.rs
@@ -141,7 +141,7 @@ impl StatusReporter {
                 let _ = self.term.write_line(&format!(
                     "  {} {}",
                     style("...").dim(),
-                    style(format!("and {} more files", remaining)).dim()
+                    style(format!("and {remaining} more files")).dim()
                 ));
             }
         }
@@ -240,7 +240,7 @@ impl EnhancedIndexingProgress {
                 .unwrap()
                 .progress_chars("●◐○  "),
         );
-        file_pb.set_message(format!("📄 {}", file_name));
+        file_pb.set_message(format!("📄 {file_name}"));
 
         self.current_file_progress = Some(file_pb);
     }
@@ -248,7 +248,7 @@ impl EnhancedIndexingProgress {
     pub fn update_chunk_progress(&mut self, chunk_number: usize, chunk_size: usize) {
         if let Some(ref pb) = self.current_file_progress {
             pb.set_position(chunk_number as u64);
-            pb.set_message(format!("🔢 chunk {} ({} chars)", chunk_number, chunk_size));
+            pb.set_message(format!("🔢 chunk {chunk_number} ({chunk_size} chars)"));
         }
     }
 
@@ -275,7 +275,7 @@ impl EnhancedIndexingProgress {
 
         // Complete current file progress bar
         if let Some(pb) = self.current_file_progress.take() {
-            pb.finish_with_message(format!("✓ {} chunks", chunks_processed));
+            pb.finish_with_message(format!("✓ {chunks_processed} chunks"));
         }
     }
 

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -137,7 +137,7 @@ fn read_manifest_updated(dir: &Path) -> u64 {
     let manifest: serde_json::Value = serde_json::from_slice(&data).expect("valid json");
     manifest
         .get("updated")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .expect("updated timestamp")
 }
 
@@ -365,7 +365,7 @@ fn test_topk_limit() {
     // Create multiple files with matches
     for i in 1..=10 {
         fs::write(
-            temp_dir.path().join(format!("file{}.txt", i)),
+            temp_dir.path().join(format!("file{i}.txt")),
             "match content",
         )
         .unwrap();
@@ -756,9 +756,7 @@ fn test_add_single_file_to_index() {
     // Check for success message in either stdout or stderr
     assert!(
         stdout.contains("Added") || stderr.contains("Added"),
-        "Expected 'Added' in output, got stdout: {}, stderr: {}",
-        stdout,
-        stderr
+        "Expected 'Added' in output, got stdout: {stdout}, stderr: {stderr}"
     );
 
     // Verify the file was actually added by searching for it
@@ -857,8 +855,7 @@ fn test_no_ckignore_flag_disables_hierarchical_ignore() {
     // With --no-ckignore, should find .tmp files
     assert!(
         stdout.contains("ignored.tmp") || stdout.contains("also_ignored.tmp"),
-        "Should find .tmp files when --no-ckignore is used. Output: {}",
-        stdout
+        "Should find .tmp files when --no-ckignore is used. Output: {stdout}"
     );
 
     // Test WITHOUT --no-ckignore flag (default behavior) - .tmp files should be EXCLUDED
@@ -874,8 +871,7 @@ fn test_no_ckignore_flag_disables_hierarchical_ignore() {
     // Without --no-ckignore (default), should NOT find .tmp files
     assert!(
         !stdout.contains("ignored.tmp") && !stdout.contains("also_ignored.tmp"),
-        "Should NOT find .tmp files when .ckignore is active (default). Output: {}",
-        stdout
+        "Should NOT find .tmp files when .ckignore is active (default). Output: {stdout}"
     );
 
     // Should still find .txt files
@@ -899,10 +895,10 @@ fn test_mixedbread_index_and_search() {
     // Create test files with semantic content
     fs::write(
         temp_dir.path().join("rust_error.rs"),
-        r#"fn handle_error() -> Result<String, String> {
+        r"fn handle_error() -> Result<String, String> {
     let result = risky_operation()?;
     Ok(result)
-}"#,
+}",
     )
     .unwrap();
     fs::write(
@@ -946,13 +942,12 @@ fn test_mixedbread_index_and_search() {
         .expect("embedding_model should be set");
     assert!(
         embedding_model.contains("mxbai-embed-xsmall-v1"),
-        "Manifest should record Mixedbread model, got: {}",
-        embedding_model
+        "Manifest should record Mixedbread model, got: {embedding_model}"
     );
 
     let embedding_dimensions = manifest
         .get("embedding_dimensions")
-        .and_then(|v| v.as_u64())
+        .and_then(serde_json::Value::as_u64)
         .expect("embedding_dimensions should be set");
     assert_eq!(
         embedding_dimensions, 384,

--- a/ck-cli/tests/mcp_tests.rs
+++ b/ck-cli/tests/mcp_tests.rs
@@ -261,8 +261,7 @@ async fn test_mcp_top_k_page_size_interaction() {
             let match_count = matches.len();
             assert!(
                 match_count <= 3,
-                "First page should have at most 3 matches, got {}",
-                match_count
+                "First page should have at most 3 matches, got {match_count}"
             );
         }
 
@@ -270,16 +269,14 @@ async fn test_mcp_top_k_page_size_interaction() {
         if let Some(total_count) = response["results"]["total_count"].as_u64() {
             assert!(
                 total_count <= 5,
-                "Total count should respect top_k=5, got {}",
-                total_count
+                "Total count should respect top_k=5, got {total_count}"
             );
         }
 
         // Check that summary reflects correct top_k
         assert!(
             summary.contains("top_k: 5"),
-            "Summary should show top_k: 5, got: {}",
-            summary
+            "Summary should show top_k: 5, got: {summary}"
         );
     }
 
@@ -303,8 +300,7 @@ async fn test_mcp_top_k_page_size_interaction() {
         if let Some(total_count) = response2["results"]["total_count"].as_u64() {
             assert!(
                 total_count <= 2,
-                "Should respect top_k=2 limit, got {} total",
-                total_count
+                "Should respect top_k=2 limit, got {total_count} total"
             );
         }
 
@@ -312,16 +308,14 @@ async fn test_mcp_top_k_page_size_interaction() {
             let match_count = matches.len();
             assert!(
                 match_count <= 2,
-                "Should respect top_k=2 limit, got {} matches",
-                match_count
+                "Should respect top_k=2 limit, got {match_count} matches"
             );
         }
 
         // Check that summary reflects correct top_k
         assert!(
             summary2.contains("top_k: 2"),
-            "Summary should show top_k: 2, got: {}",
-            summary2
+            "Summary should show top_k: 2, got: {summary2}"
         );
     }
 }

--- a/ck-core/src/lib.rs
+++ b/ck-core/src/lib.rs
@@ -114,7 +114,7 @@ impl std::fmt::Display for Language {
             Language::Elixir => "elixir",
             Language::Pdf => "pdf",
         };
-        write!(f, "{}", name)
+        write!(f, "{name}")
     }
 }
 
@@ -355,7 +355,7 @@ impl JsonlSearchResult {
         Self {
             path: result.file.to_string_lossy().to_string(),
             span: result.span.clone(),
-            language: result.lang.as_ref().map(|l| l.to_string()),
+            language: result.lang.as_ref().map(std::string::ToString::to_string),
             snippet: if include_snippet {
                 Some(result.preview.clone())
             } else {
@@ -451,7 +451,7 @@ pub fn get_default_exclude_patterns() -> Vec<String> {
 
 /// Get default .ckignore file content
 pub fn get_default_ckignore_content() -> &'static str {
-    r#"# .ckignore - Default patterns for ck semantic search
+    r"# .ckignore - Default patterns for ck semantic search
 # Created automatically during first index
 # Syntax: same as .gitignore (glob patterns, ! for negation)
 
@@ -516,7 +516,7 @@ pub fn get_default_ckignore_content() -> &'static str {
 *.yml
 
 # Add your custom patterns below this line
-"#
+"
 }
 
 /// Read and parse .ckignore file, returning patterns
@@ -531,9 +531,9 @@ pub fn read_ckignore_patterns(repo_root: &Path) -> Result<Vec<String>> {
 
     let patterns: Vec<String> = content
         .lines()
-        .map(|line| line.trim())
+        .map(str::trim)
         .filter(|line| !line.is_empty() && !line.starts_with('#'))
-        .map(|line| line.to_string())
+        .map(std::string::ToString::to_string)
         .collect();
 
     Ok(patterns)
@@ -1350,14 +1350,14 @@ mod tests {
         let ckignore_path = test_path.join(".ckignore");
         fs::write(
             &ckignore_path,
-            r#"# Comment line
+            r"# Comment line
 *.png
 *.jpg
 
 # Another comment
 *.json
 *.yaml
-"#,
+",
         )
         .unwrap();
 
@@ -1380,14 +1380,14 @@ mod tests {
         let ckignore_path = test_path.join(".ckignore");
         fs::write(
             &ckignore_path,
-            r#"
+            r"
 *.png
 
 *.jpg
 
 
 *.json
-"#,
+",
         )
         .unwrap();
 

--- a/ck-embed/examples/list_models.rs
+++ b/ck-embed/examples/list_models.rs
@@ -37,10 +37,10 @@ fn run_example() {
     ];
 
     for (name, model) in models {
-        println!("✓ {} - Available", name);
+        println!("✓ {name} - Available");
 
         // Try to get model info without downloading
-        println!("  Model enum variant: {:?}", model);
+        println!("  Model enum variant: {model:?}");
     }
 
     println!("\nNote: This just shows the models defined in the enum.");

--- a/ck-embed/examples/test_mixedbread.rs
+++ b/ck-embed/examples/test_mixedbread.rs
@@ -28,14 +28,14 @@ fn run_example() {
     let registry = ModelRegistry::default();
     match registry.resolve(Some("mxbai-xsmall")) {
         Ok((alias, config)) => {
-            println!("   ✅ Resolved alias: '{}'", alias);
+            println!("   ✅ Resolved alias: '{alias}'");
             println!("      Model name: {}", config.name);
             println!("      Provider: {}", config.provider);
             println!("      Dimensions: {}", config.dimensions);
             println!("      Max tokens: {}", config.max_tokens);
         }
         Err(e) => {
-            println!("   ❌ Failed to resolve alias: {}", e);
+            println!("   ❌ Failed to resolve alias: {e}");
             return;
         }
     }
@@ -85,10 +85,7 @@ fn run_example() {
                     // Check normalization (L2 norm should be ~1.0)
                     for (i, emb) in embeddings.iter().enumerate() {
                         let norm: f32 = emb.iter().map(|x| x * x).sum::<f32>().sqrt();
-                        println!(
-                            "      Embedding {} L2 norm: {:.6} (should be ~1.0)",
-                            i, norm
-                        );
+                        println!("      Embedding {i} L2 norm: {norm:.6} (should be ~1.0)");
                         assert!(
                             (norm - 1.0).abs() < 0.01,
                             "Embeddings should be L2-normalized"
@@ -96,14 +93,14 @@ fn run_example() {
                     }
                 }
                 Err(e) => {
-                    println!("   ❌ Failed to generate embeddings: {}", e);
+                    println!("   ❌ Failed to generate embeddings: {e}");
                     return;
                 }
             }
         }
         Err(e) => {
-            println!("   ❌ Failed to create Mixedbread embedder: {}", e);
-            println!("      Error details: {:?}", e);
+            println!("   ❌ Failed to create Mixedbread embedder: {e}");
+            println!("      Error details: {e:?}");
             return;
         }
     }
@@ -115,12 +112,12 @@ fn run_example() {
     let rerank_registry = RerankModelRegistry::default();
     match rerank_registry.resolve(Some("mxbai")) {
         Ok((alias, config)) => {
-            println!("   ✅ Resolved reranker alias: '{}'", alias);
+            println!("   ✅ Resolved reranker alias: '{alias}'");
             println!("      Model name: {}", config.name);
             println!("      Provider: {}", config.provider);
         }
         Err(e) => {
-            println!("   ❌ Failed to resolve reranker alias: {}", e);
+            println!("   ❌ Failed to resolve reranker alias: {e}");
             return;
         }
     }
@@ -142,7 +139,7 @@ fn run_example() {
                 "Rust provides excellent error handling mechanisms".to_string(),
                 "JavaScript async programming patterns".to_string(),
             ];
-            println!("   Query: '{}'", query);
+            println!("   Query: '{query}'");
             println!("   Reranking {} documents...", documents.len());
 
             match reranker.rerank(query, &documents) {
@@ -183,14 +180,14 @@ fn run_example() {
                     }
                 }
                 Err(e) => {
-                    println!("   ❌ Failed to rerank: {}", e);
+                    println!("   ❌ Failed to rerank: {e}");
                     return;
                 }
             }
         }
         Err(e) => {
-            println!("   ❌ Failed to create Mixedbread reranker: {}", e);
-            println!("      Error details: {:?}", e);
+            println!("   ❌ Failed to create Mixedbread reranker: {e}");
+            println!("      Error details: {e:?}");
             return;
         }
     }

--- a/ck-embed/examples/test_nomic.rs
+++ b/ck-embed/examples/test_nomic.rs
@@ -39,13 +39,13 @@ fn run_example() {
                     );
                 }
                 Err(e) => {
-                    println!("❌ Failed to generate embeddings: {}", e);
+                    println!("❌ Failed to generate embeddings: {e}");
                 }
             }
         }
         Err(e) => {
-            println!("❌ Failed to create Nomic embedder: {}", e);
-            println!("   Error details: {:?}", e);
+            println!("❌ Failed to create Nomic embedder: {e}");
+            println!("   Error details: {e:?}");
 
             println!("\n--- Trying alternative model names ---");
 
@@ -57,10 +57,10 @@ fn run_example() {
             ];
 
             for alt in alternatives {
-                println!("Trying: {}", alt);
+                println!("Trying: {alt}");
                 match create_embedder(Some(alt)) {
-                    Ok(_) => println!("  ✅ {} works!", alt),
-                    Err(e) => println!("  ❌ {} failed: {}", alt, e),
+                    Ok(_) => println!("  ✅ {alt} works!"),
+                    Err(e) => println!("  ❌ {alt} failed: {e}"),
                 }
             }
         }
@@ -69,6 +69,6 @@ fn run_example() {
     println!("\n--- Testing working BGE model for comparison ---");
     match create_embedder(Some("BAAI/bge-small-en-v1.5")) {
         Ok(embedder) => println!("✅ BGE model works: {} dims", embedder.dim()),
-        Err(e) => println!("❌ Even BGE failed: {}", e),
+        Err(e) => println!("❌ Even BGE failed: {e}"),
     }
 }

--- a/ck-embed/examples/test_reranking.rs
+++ b/ck-embed/examples/test_reranking.rs
@@ -30,7 +30,7 @@ fn run_example() {
         "exception handling best practices".to_string(),
     ];
 
-    println!("\nQuery: '{}'", query);
+    println!("\nQuery: '{query}'");
     println!("Documents to rerank:");
     for (i, doc) in documents.iter().enumerate() {
         println!("  {}: {}", i + 1, doc);

--- a/ck-embed/src/lib.rs
+++ b/ck-embed/src/lib.rs
@@ -97,7 +97,7 @@ pub fn create_embedder_for_config(
                 );
             }
         }
-        provider => bail!("Unsupported embedding provider '{}'", provider),
+        provider => bail!("Unsupported embedding provider '{provider}'"),
     }
 }
 
@@ -188,7 +188,7 @@ impl FastEmbedder {
         std::fs::create_dir_all(&model_cache_dir)?;
 
         if let Some(ref callback) = progress_callback {
-            callback(&format!("Initializing model: {}", model_name));
+            callback(&format!("Initializing model: {model_name}"));
 
             // Check if model already exists
             let model_exists = Self::check_model_exists(&model_cache_dir, model_name);
@@ -199,7 +199,7 @@ impl FastEmbedder {
                     model_cache_dir.display()
                 ));
             } else {
-                callback(&format!("Using cached model: {}", model_name));
+                callback(&format!("Using cached model: {model_name}"));
             }
         }
 
@@ -276,7 +276,7 @@ impl Embedder for FastEmbedder {
     }
 
     fn embed(&mut self, texts: &[String]) -> Result<Vec<Vec<f32>>> {
-        let text_refs: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        let text_refs: Vec<&str> = texts.iter().map(std::string::String::as_str).collect();
         let embeddings = self.model.embed(text_refs, None)?;
         Ok(embeddings)
     }

--- a/ck-embed/src/mixedbread.rs
+++ b/ck-embed/src/mixedbread.rs
@@ -85,7 +85,7 @@ impl MixedbreadEmbedder {
 
         let seq_len = encodings
             .iter()
-            .map(|encoding| encoding.len())
+            .map(tokenizers::Encoding::len)
             .max()
             .unwrap_or(1)
             .min(self.max_length)
@@ -262,7 +262,7 @@ impl MixedbreadReranker {
 
         let seq_len = encodings
             .iter()
-            .map(|encoding| encoding.len())
+            .map(tokenizers::Encoding::len)
             .max()
             .unwrap_or(1)
             .min(self.max_length)

--- a/ck-embed/src/reranker.rs
+++ b/ck-embed/src/reranker.rs
@@ -73,7 +73,7 @@ pub fn create_reranker_for_config(
                 );
             }
         }
-        provider => bail!("Unsupported reranker provider '{}'", provider),
+        provider => bail!("Unsupported reranker provider '{provider}'"),
     }
 }
 
@@ -144,7 +144,7 @@ impl FastReranker {
         std::fs::create_dir_all(&model_cache_dir)?;
 
         if let Some(ref callback) = progress_callback {
-            callback(&format!("Initializing reranker model: {}", model_name));
+            callback(&format!("Initializing reranker model: {model_name}"));
 
             // Check if model already exists
             let model_exists = Self::check_model_exists(&model_cache_dir, model_name);
@@ -155,7 +155,7 @@ impl FastReranker {
                     model_cache_dir.display()
                 ));
             } else {
-                callback(&format!("Using cached reranker model: {}", model_name));
+                callback(&format!("Using cached reranker model: {model_name}"));
             }
         }
 
@@ -206,7 +206,7 @@ impl Reranker for FastReranker {
 
     fn rerank(&mut self, query: &str, documents: &[String]) -> Result<Vec<RerankResult>> {
         // Convert documents to string references
-        let docs: Vec<&str> = documents.iter().map(|s| s.as_str()).collect();
+        let docs: Vec<&str> = documents.iter().map(std::string::String::as_str).collect();
 
         // Get reranking scores - fastembed rerank takes (query, documents)
         let results = self.model.rerank(query, docs, true, None)?;

--- a/ck-embed/src/tokenizer.rs
+++ b/ck-embed/src/tokenizer.rs
@@ -112,7 +112,7 @@ mod tests {
         let text = "Hello, world!";
         let tokens = TokenEstimator::estimate_tokens(text);
         // Should be around 3 tokens, estimation might vary
-        assert!((2..=4).contains(&tokens), "Got {} tokens", tokens);
+        assert!((2..=4).contains(&tokens), "Got {tokens} tokens");
     }
 
     #[test]
@@ -126,7 +126,7 @@ fn main() {
 "#;
         let tokens = TokenEstimator::estimate_tokens(code);
         // Code typically has more tokens due to symbols
-        assert!((15..=25).contains(&tokens), "Got {} tokens", tokens);
+        assert!((15..=25).contains(&tokens), "Got {tokens} tokens");
     }
 
     #[test]
@@ -152,19 +152,19 @@ fn main() {
 
     #[test]
     fn test_code_detection() {
-        let code = r#"
+        let code = r"
 pub fn calculate(x: i32) -> i32 {
     let result = x * 2;
     return result;
 }
-"#;
+";
         let tokens = TokenEstimator::estimate_tokens(code);
 
-        let text = r#"
+        let text = r"
 This is a paragraph about programming.
 It contains some discussion of functions and variables.
 But it's written in natural language.
-"#;
+";
         let text_tokens = TokenEstimator::estimate_tokens(text);
 
         // Code should generally have slightly more tokens per character
@@ -174,9 +174,7 @@ But it's written in natural language.
 
         assert!(
             code_ratio >= text_ratio * 0.8,
-            "Code ratio {} should be similar to or higher than text ratio {}",
-            code_ratio,
-            text_ratio
+            "Code ratio {code_ratio} should be similar to or higher than text ratio {text_ratio}"
         );
     }
 }

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -753,20 +753,20 @@ async fn lexical_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
     let _schema = schema_builder.build();
 
     let index = Index::open_in_dir(&tantivy_index_path)
-        .map_err(|e| CkError::Index(format!("Failed to open tantivy index: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to open tantivy index: {e}")))?;
 
     let reader = index
         .reader_builder()
         .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()
-        .map_err(|e| CkError::Index(format!("Failed to create index reader: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to create index reader: {e}")))?;
 
     let searcher = reader.searcher();
     let query_parser = QueryParser::for_index(&index, vec![content_field]);
 
     let query = query_parser
         .parse_query(&options.query)
-        .map_err(|e| CkError::Search(format!("Failed to parse query: {}", e)))?;
+        .map_err(|e| CkError::Search(format!("Failed to parse query: {e}")))?;
 
     let top_docs = if let Some(top_k) = options.top_k {
         searcher.search(&query, &TopDocs::with_limit(top_k))?
@@ -863,11 +863,11 @@ async fn build_tantivy_index(options: &SearchOptions) -> Result<Vec<SearchResult
     let schema = schema_builder.build();
 
     let index = Index::create_in_dir(&tantivy_index_path, schema.clone())
-        .map_err(|e| CkError::Index(format!("Failed to create tantivy index: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to create tantivy index: {e}")))?;
 
     let mut index_writer = index
         .writer(50_000_000)
-        .map_err(|e| CkError::Index(format!("Failed to create index writer: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to create index writer: {e}")))?;
 
     let files = filter_files_by_include(
         collect_files(index_root, true, &options.exclude_patterns)?,
@@ -886,7 +886,7 @@ async fn build_tantivy_index(options: &SearchOptions) -> Result<Vec<SearchResult
 
     index_writer
         .commit()
-        .map_err(|e| CkError::Index(format!("Failed to commit index: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to commit index: {e}")))?;
 
     // After building, search again with the same options
     let tantivy_index_path = index_root.join(".ck").join("tantivy_index");
@@ -896,20 +896,20 @@ async fn build_tantivy_index(options: &SearchOptions) -> Result<Vec<SearchResult
     let _schema = schema_builder.build();
 
     let index = Index::open_in_dir(&tantivy_index_path)
-        .map_err(|e| CkError::Index(format!("Failed to open tantivy index: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to open tantivy index: {e}")))?;
 
     let reader = index
         .reader_builder()
         .reload_policy(ReloadPolicy::OnCommitWithDelay)
         .try_into()
-        .map_err(|e| CkError::Index(format!("Failed to create index reader: {}", e)))?;
+        .map_err(|e| CkError::Index(format!("Failed to create index reader: {e}")))?;
 
     let searcher = reader.searcher();
     let query_parser = QueryParser::for_index(&index, vec![content_field]);
 
     let query = query_parser
         .parse_query(&options.query)
-        .map_err(|e| CkError::Search(format!("Failed to parse query: {}", e)))?;
+        .map_err(|e| CkError::Search(format!("Failed to parse query: {e}")))?;
 
     let top_docs = if let Some(top_k) = options.top_k {
         searcher.search(&query, &TopDocs::with_limit(top_k))?
@@ -1468,11 +1468,7 @@ mod tests {
 
         // Create multiple files with matches
         for i in 0..10 {
-            fs::write(
-                temp_dir.path().join(format!("file{}.txt", i)),
-                "test content",
-            )
-            .unwrap();
+            fs::write(temp_dir.path().join(format!("file{i}.txt")), "test content").unwrap();
         }
 
         let options = SearchOptions {

--- a/ck-engine/src/semantic_v3.rs
+++ b/ck-engine/src/semantic_v3.rs
@@ -209,7 +209,7 @@ pub async fn semantic_search_v3_with_progress(
         match ck_embed::create_reranker_for_config(&rerank_config, None) {
             Ok(mut reranker) => {
                 if let Some(ref callback) = progress_callback {
-                    callback(&format!("Reranking results with model {}", rerank_alias));
+                    callback(&format!("Reranking results with model {rerank_alias}"));
                 }
 
                 let documents: Vec<String> = results.iter().map(|r| r.preview.clone()).collect();

--- a/ck-index/src/lib.rs
+++ b/ck-index/src/lib.rs
@@ -100,7 +100,7 @@ fn build_overrides(
         if pattern.starts_with('!') {
             builder.add(pattern)?;
         } else {
-            builder.add(&format!("!{}", pattern))?;
+            builder.add(&format!("!{pattern}"))?;
         }
     }
 
@@ -182,7 +182,7 @@ fn should_include_file(entry: &ignore::DirEntry, index_dir: &Path) -> bool {
 /// Apply common filtering to a WalkBuilder iterator
 fn filter_and_collect_files(walker: ignore::Walk, index_dir: &Path) -> Vec<PathBuf> {
     walker
-        .filter_map(|entry| entry.ok())
+        .filter_map(std::result::Result::ok)
         .filter(|entry| should_include_file(entry, index_dir))
         .map(|entry| entry.path().to_path_buf())
         .collect()
@@ -897,10 +897,7 @@ pub async fn smart_update_index_with_detailed_progress(
         for file_path in files_to_update.iter() {
             // Check for interrupt
             if INTERRUPTED.load(Ordering::SeqCst) {
-                eprintln!(
-                    "Indexing interrupted. {} files processed.",
-                    _processed_count
-                );
+                eprintln!("Indexing interrupted. {_processed_count} files processed.");
                 break;
             }
 
@@ -1014,10 +1011,7 @@ pub async fn smart_update_index_with_detailed_progress(
         while let Ok((file_path, entry)) = rx.recv() {
             // Check for interrupt
             if INTERRUPTED.load(Ordering::SeqCst) {
-                eprintln!(
-                    "Indexing interrupted. {} files processed.",
-                    _processed_count
-                );
+                eprintln!("Indexing interrupted. {_processed_count} files processed.");
                 drop(rx); // Drop receiver to signal worker to stop
                 break;
             }
@@ -1207,9 +1201,7 @@ fn index_single_file_with_progress(
                         let embeddings = embedder.embed(std::slice::from_ref(&chunk.text))?;
                         embeddings.into_iter().next().ok_or_else(|| {
                             anyhow::anyhow!(
-                                "Embedder returned empty results for chunk {} in file {:?}. This may indicate an issue with the embedding model or chunk content.",
-                                chunk_index,
-                                file_path
+                                "Embedder returned empty results for chunk {chunk_index} in file {file_path:?}. This may indicate an issue with the embedding model or chunk content."
                             )
                         })?
                     }
@@ -1219,9 +1211,7 @@ fn index_single_file_with_progress(
                     let embeddings = embedder.embed(std::slice::from_ref(&chunk.text))?;
                     embeddings.into_iter().next().ok_or_else(|| {
                         anyhow::anyhow!(
-                            "Embedder returned empty results for chunk {} in file {:?}. This may indicate an issue with the embedding model or chunk content.",
-                            chunk_index,
-                            file_path
+                            "Embedder returned empty results for chunk {chunk_index} in file {file_path:?}. This may indicate an issue with the embedding model or chunk content."
                         )
                     })?
                 };
@@ -2064,8 +2054,7 @@ mod tests {
         assert_eq!(
             files.len(),
             1,
-            "With respect_gitignore=true, .git/info/exclude should hide files, found: {:?}",
-            files
+            "With respect_gitignore=true, .git/info/exclude should hide files, found: {files:?}"
         );
 
         // With respect_gitignore=false, .git/info/exclude should be ignored
@@ -2078,8 +2067,7 @@ mod tests {
         assert_eq!(
             files.len(),
             2,
-            "With respect_gitignore=false, .git/info/exclude should be ignored, found: {:?}",
-            files
+            "With respect_gitignore=false, .git/info/exclude should be ignored, found: {files:?}"
         );
     }
 

--- a/ck-tui/src/app.rs
+++ b/ck-tui/src/app.rs
@@ -294,7 +294,7 @@ impl TuiApp {
         } else {
             "Snippet"
         };
-        self.state.status_message = format!("View: {}", mode_text);
+        self.state.status_message = format!("View: {mode_text}");
         self.save_config();
     }
 
@@ -458,7 +458,7 @@ impl TuiApp {
                 self.state.indexing_progress = None;
                 self.state.indexing_started_at = None;
                 self.state.last_indexing_update = None;
-                self.state.status_message = format!("Search error: {}", error);
+                self.state.status_message = format!("Search error: {error}");
             }
         }
     }
@@ -650,7 +650,7 @@ impl TuiApp {
                 Ok(search_results) => {
                     let elapsed_ms = started_at.elapsed().as_millis();
                     let summary = if search_results.matches.is_empty() {
-                        format!("No results ({} ms)", elapsed_ms)
+                        format!("No results ({elapsed_ms} ms)")
                     } else {
                         format!(
                             "Found {} results ({} ms)",
@@ -957,21 +957,21 @@ impl TuiApp {
             // Emacs: open first file only (multi-file is complex)
             let (file, line) = &files_to_open[0];
             command
-                .arg(format!("+{}", line))
+                .arg(format!("+{line}"))
                 .arg(file.display().to_string())
                 .status()?
         } else if editor_basename.contains("nano") {
             // Nano: open first file only
             let (file, line) = &files_to_open[0];
             command
-                .arg(format!("+{}", line))
+                .arg(format!("+{line}"))
                 .arg(file.display().to_string())
                 .status()?
         } else {
             // Vim/Neovim: can open multiple files with -p (tabs)
             for (file, line) in &files_to_open {
                 command
-                    .arg(format!("+{}", line))
+                    .arg(format!("+{line}"))
                     .arg(file.display().to_string());
             }
             if files_to_open.len() > 1 {

--- a/ck-tui/src/chunks.rs
+++ b/ck-tui/src/chunks.rs
@@ -187,7 +187,7 @@ pub fn collect_chunk_display_lines(
                 .breadcrumb
                 .as_deref()
                 .filter(|crumb| !crumb.is_empty())
-                .map(|crumb| format!(" ({})", crumb))
+                .map(|crumb| format!(" ({crumb})"))
                 .unwrap_or_else(|| {
                     if !meta.ancestry.is_empty() {
                         format!(" ({})", meta.ancestry.join("::"))
@@ -197,11 +197,11 @@ pub fn collect_chunk_display_lines(
                 });
             let token_hint = meta
                 .estimated_tokens
-                .map(|tokens| format!(" • {} tokens", tokens))
+                .map(|tokens| format!(" • {tokens} tokens"))
                 .unwrap_or_default();
 
             // Create a more bar-like header design with better spacing
-            let bar_text = format!("{} {}{}", chunk_kind, breadcrumb_text, token_hint);
+            let bar_text = format!("{chunk_kind} {breadcrumb_text}{token_hint}");
             rows.push(ChunkDisplayLine::Label {
                 prefix: max_depth,
                 text: bar_text,
@@ -250,7 +250,7 @@ pub fn collect_chunk_display_lines(
             .iter()
             .find(|meta| line_num >= meta.span.line_start && line_num <= meta.span.line_end);
 
-        let has_any_structural = depth_slots.iter().any(|slot| slot.is_some());
+        let has_any_structural = depth_slots.iter().any(std::option::Option::is_some);
         let has_any_chunk = has_any_structural || text_chunk_here.is_some();
         let in_matched_chunk = chunk_meta
             .map(|meta| line_num >= meta.span.line_start && line_num <= meta.span.line_end)
@@ -364,7 +364,7 @@ pub fn chunk_display_line_to_string(line: &ChunkDisplayLine) -> String {
             output.push(' ');
 
             // Add line number with fixed width (at least 4 chars)
-            output.push_str(&format!("{:4} | ", line_num));
+            output.push_str(&format!("{line_num:4} | "));
 
             // Add line text
             output.push_str(text);
@@ -414,7 +414,7 @@ pub fn chunk_file_live(file_path: &Path) -> Result<(Vec<String>, Vec<IndexedChun
     // Use model-aware chunking (same approach as --dump-chunks)
     let default_model = "nomic-embed-text-v1.5";
     let chunks = ck_chunk::chunk_text_with_model(&content, detected_lang, Some(default_model))
-        .map_err(|err| format!("Failed to chunk file: {}", err))?;
+        .map_err(|err| format!("Failed to chunk file: {err}"))?;
 
     // Convert chunks to IndexedChunkMeta format
     let chunk_metas = convert_chunks_to_meta(chunks);

--- a/ck-tui/src/commands.rs
+++ b/ck-tui/src/commands.rs
@@ -30,10 +30,8 @@ pub fn execute_command(state: &mut TuiState) -> Result<()> {
             show_stats(state);
         }
         _ => {
-            state.status_message = format!(
-                "Unknown command: {}. Type /help for available commands",
-                cmd
-            );
+            state.status_message =
+                format!("Unknown command: {cmd}. Type /help for available commands");
         }
     }
 
@@ -203,7 +201,7 @@ pub fn show_chunks(state: &mut TuiState) {
                 "  Overlaps with: {}",
                 overlaps_with
                     .iter()
-                    .map(|n| format!("#{}", n))
+                    .map(|n| format!("#{n}"))
                     .collect::<Vec<_>>()
                     .join(", ")
             ));
@@ -277,7 +275,7 @@ fn load_chunk_spans(repo_root: &Path, file_path: &Path) -> Result<Vec<IndexedChu
     }
 
     let entry = load_index_entry(&sidecar_path)
-        .map_err(|err| format!("Failed to load chunk metadata: {}", err))?;
+        .map_err(|err| format!("Failed to load chunk metadata: {err}"))?;
     let mut metas: Vec<IndexedChunkMeta> = entry
         .chunks
         .iter()

--- a/ck-tui/src/preview.rs
+++ b/ck-tui/src/preview.rs
@@ -28,17 +28,20 @@ pub fn load_preview_lines(
 
         let cache_path = pdf::get_content_cache_path(&root, &resolved_path);
         let content = fs::read_to_string(&cache_path).map_err(|err| {
-            format!(
-                "PDF preview unavailable ({}). Run `ck --index .` to generate cache.",
-                err
-            )
+            format!("PDF preview unavailable ({err}). Run `ck --index .` to generate cache.")
         })?;
-        let lines: Vec<String> = content.lines().map(|line| line.to_string()).collect();
+        let lines: Vec<String> = content
+            .lines()
+            .map(std::string::ToString::to_string)
+            .collect();
         (content, lines)
     } else {
         let content = fs::read_to_string(&resolved_path)
             .map_err(|err| format!("Could not read {}: {}", resolved_path.display(), err))?;
-        let lines: Vec<String> = content.lines().map(|line| line.to_string()).collect();
+        let lines: Vec<String> = content
+            .lines()
+            .map(std::string::ToString::to_string)
+            .collect();
         (content, lines)
     };
 
@@ -81,7 +84,7 @@ fn load_chunk_spans(repo_root: &Path, file_path: &Path) -> Result<Vec<IndexedChu
     }
 
     let entry = load_index_entry(&sidecar_path)
-        .map_err(|err| format!("Failed to load chunk metadata: {}", err))?;
+        .map_err(|err| format!("Failed to load chunk metadata: {err}"))?;
     let mut metas: Vec<IndexedChunkMeta> = entry
         .chunks
         .iter()
@@ -132,7 +135,7 @@ pub fn render_heatmap_preview(
         let in_chunk_range = line_num >= match_line.saturating_sub(5) && line_num <= match_line + 5;
 
         let mut line_spans = vec![Span::styled(
-            format!("{:4} | ", line_num),
+            format!("{line_num:4} | "),
             if is_match_line {
                 Style::default()
                     .fg(COLOR_YELLOW)
@@ -209,7 +212,7 @@ pub fn render_syntax_preview(
 
                 let line_spans = vec![
                     Span::styled(
-                        format!("{:4} | ", line_num),
+                        format!("{line_num:4} | "),
                         if is_match_line {
                             Style::default()
                                 .fg(COLOR_YELLOW)
@@ -237,7 +240,7 @@ pub fn render_syntax_preview(
         let in_chunk_range = line_num >= match_line.saturating_sub(5) && line_num <= match_line + 5;
 
         let mut line_spans = vec![Span::styled(
-            format!("{:4} | ", line_num),
+            format!("{line_num:4} | "),
             if is_match_line {
                 Style::default()
                     .fg(COLOR_YELLOW)
@@ -289,7 +292,7 @@ pub fn render_chunks_preview(
             .breadcrumb
             .as_deref()
             .filter(|crumb| !crumb.is_empty())
-            .map(|crumb| format!(" • {}", crumb))
+            .map(|crumb| format!(" • {crumb}"))
             .unwrap_or_else(|| {
                 if !meta.ancestry.is_empty() {
                     format!(" • {}", meta.ancestry.join("::"))
@@ -299,7 +302,7 @@ pub fn render_chunks_preview(
             });
         let token_display = meta
             .estimated_tokens
-            .map(|tokens| format!(" • ~{} tokens", tokens))
+            .map(|tokens| format!(" • ~{tokens} tokens"))
             .unwrap_or_default();
 
         format!(
@@ -449,7 +452,7 @@ pub fn build_chunk_lines(
 
             // Use fixed-width line number formatting
             spans.push(Span::styled(
-                format!("{:width$} | ", line_num, width = line_num_width),
+                format!("{line_num:line_num_width$} | "),
                 if is_match_line {
                     Style::default()
                         .fg(COLOR_YELLOW)
@@ -532,12 +535,7 @@ pub fn build_chunk_strings(
                 }
             }
             line_buf.push(' ');
-            line_buf.push_str(&format!(
-                "{:width$} | {}",
-                line_num,
-                text,
-                width = line_num_width
-            ));
+            line_buf.push_str(&format!("{line_num:line_num_width$} | {text}"));
             if is_match_line {
                 line_buf.push_str("  <= match");
             }
@@ -613,7 +611,7 @@ pub fn dump_chunk_view_internal(
             .breadcrumb
             .as_deref()
             .filter(|crumb| !crumb.is_empty())
-            .map(|crumb| format!(" • {}", crumb))
+            .map(|crumb| format!(" • {crumb}"))
             .unwrap_or_else(|| {
                 if !meta.ancestry.is_empty() {
                     format!(" • {}", meta.ancestry.join("::"))
@@ -623,7 +621,7 @@ pub fn dump_chunk_view_internal(
             });
         let token_display = meta
             .estimated_tokens
-            .map(|tokens| format!(" • ~{} tokens", tokens))
+            .map(|tokens| format!(" • ~{tokens} tokens"))
             .unwrap_or_default();
 
         vec![

--- a/ck-tui/src/rendering.rs
+++ b/ck-tui/src/rendering.rs
@@ -24,10 +24,7 @@ pub fn draw_query_input(f: &mut Frame, area: Rect, state: &TuiState) {
             SearchMode::Lexical => "[LEX]",
         };
         (
-            format!(
-                "Search {} (Tab to cycle, /help for commands)",
-                mode_indicator
-            ),
+            format!("Search {mode_indicator} (Tab to cycle, /help for commands)"),
             Style::default().fg(COLOR_YELLOW),
         )
     };
@@ -125,7 +122,7 @@ pub fn draw_status_bar(f: &mut Frame, area: Rect, state: &TuiState) {
 
         status_spans.push(Span::raw(" | "));
         status_spans.push(Span::styled(
-            format!("{} ", spinner),
+            format!("{spinner} "),
             Style::default().fg(COLOR_YELLOW),
         ));
 
@@ -133,7 +130,7 @@ pub fn draw_status_bar(f: &mut Frame, area: Rect, state: &TuiState) {
         if let Some(progress) = state.indexing_progress {
             let pct = (progress * 100.0).clamp(0.0, 100.0).round() as i32;
             status_spans.push(Span::styled(
-                format!("[{:>3}%] ", pct),
+                format!("[{pct:>3}%] "),
                 Style::default()
                     .fg(COLOR_GREEN)
                     .add_modifier(Modifier::BOLD),
@@ -180,7 +177,7 @@ pub fn draw_status_bar(f: &mut Frame, area: Rect, state: &TuiState) {
             stats.total_files, stats.total_chunks
         )
     } else if let Some(err) = state.index_stats_error.as_ref() {
-        format!("Index error: {}", err)
+        format!("Index error: {err}")
     } else {
         "Index: --".to_string()
     };


### PR DESCRIPTION
## Summary

Mechanical \`cargo clippy --fix\` cleanup with three pedantic lints, opt-in just for this pass:

- **\`clippy::uninlined_format_args\`** — \`format!(\"{}\", x)\` → \`format!(\"{x}\")\`
- **\`clippy::redundant_closure_for_method_calls\`** — \`.map(|x| x.to_string())\` → \`.map(ToString::to_string)\`
- **\`clippy::needless_raw_string_hashes\`** — drop \`#\` when the raw string doesn't need them

27 files touched, all single-line substitutions. No logic changes, no behavior changes.

## Why now

Reduces incidental fmt drift on future PRs (most files would otherwise gain one or two inlined-format-arg changes whenever someone touches them). One-time cleanup so the diff is concentrated rather than scattered.

## What I did NOT do

- Did NOT add \`#![warn(clippy::pedantic)]\` to any crate. The default warn level remains the CI gate. If we wanted pedantic-strict permanently, that's a separate discussion (it has ~150 other warnings — some are good, many are noise).
- Did NOT touch any code with actual logic.

## Verified

- \`cargo check --workspace\` clean
- \`cargo fmt --all --check\` clean
- \`cargo clippy --workspace --all-features --all-targets -- -D warnings\` clean (existing CI gate)
- ck-engine tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)