### PR TITLE
fix(ck-cli): don't panic on broken pipe (ck ... | head)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,6 +539,7 @@ dependencies = [
  "glob",
  "globset",
  "indicatif",
+ "libc",
  "openssl",
  "owo-colors",
  "ratatui",

--- a/UNEXPECTED.md
+++ b/UNEXPECTED.md
@@ -41,6 +41,32 @@ This file tracks instances where ck behaves unexpectedly during testing or usage
 
 ---
 
+**Command:** `ck -i "rrf|reciprocal" ck-engine/src/lib.rs | head -8`
+**Expected:** First 8 matches, clean exit (grep behavior under SIGPIPE)
+**Actual:** Rust panic printed to stderr: `thread 'main' panicked at ... failed printing to stdout: Broken pipe (os error 32)`
+**Date:** 2026-06-09
+**Status:** Fixed (fix/sigpipe-panic — SIGPIPE default disposition restored on Unix at startup; exits 141 like grep)
+**Notes:** Piping into `head`/`less` is core grep usage. Needs SIGPIPE handling (e.g. restore default SIGPIPE disposition on Unix, or treat BrokenPipe write errors as silent success).
+
+---
+
+**Command:** MCP `index_status` on this repo
+**Expected:** Index size reflecting 1825 embedded chunks (tens of MB)
+**Actual:** `index_size_bytes: 928` — appears to report only the manifest, not the actual `.ck` directory size
+**Date:** 2026-06-09
+**Status:** Open
+
+---
+
+**Command:** MCP `semantic_search` query "where does the RRF reciprocal rank fusion merging of regex and semantic results happen"
+**Expected:** `hybrid_search_with_progress` / RRF scoring code in ck-engine/src/lib.rs (it exists, has RRF comments, and is regex-findable)
+**Actual:** Single result: a docs-site roadmap.md bullet (score 0.60). The actual implementation never surfaced; default threshold 0.6 filtered everything else. Same miss via CLI `--sem` scoped to ck-engine/ (best candidate scored 0.578, and was the wrong chunk). `--hybrid "RRF reciprocal rank fusion"` also failed to surface it in top 5.
+**Date:** 2026-06-09
+**Status:** Open
+**Notes:** Also: that first MCP search reported `search_time_ms: 1839209` (~30 min) — metric is clearly wrong, possibly accumulating indexing time or wrong unit. Subsequent search reported 887ms.
+
+---
+
 ## Instructions
 
 When you encounter unexpected behavior while using ck:

--- a/ck-cli/Cargo.toml
+++ b/ck-cli/Cargo.toml
@@ -60,6 +60,9 @@ base64 = { workspace = true }
 sha2 = { workspace = true }
 dirs = "5.0"
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [features]
 default = ["fastembed", "mixedbread"]
 fastembed = ["ck-embed/fastembed", "ck-index/fastembed", "ck-engine/fastembed", "ck-chunk/fastembed", "ck-tui/fastembed"]

--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -865,8 +865,25 @@ async fn inspect_file_metadata(file_path: &PathBuf, status: &StatusReporter) -> 
     Ok(())
 }
 
+/// Restore SIGPIPE's default disposition so that writing to a closed pipe
+/// (e.g. `ck pattern | head`) terminates the process silently with status 141,
+/// matching grep, instead of panicking on a BrokenPipe write error. Rust's
+/// runtime ignores SIGPIPE by default, which turns EPIPE into a panic inside
+/// `println!`.
+#[cfg(unix)]
+fn reset_sigpipe() {
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+}
+
+#[cfg(not(unix))]
+fn reset_sigpipe() {}
+
 #[tokio::main]
 async fn main() {
+    reset_sigpipe();
+
     if let Err(e) = run_main().await {
         eprintln!("DETAILED ERROR: {e:#}");
         eprintln!("DEBUG: Error occurred in main");

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -1069,3 +1069,53 @@ fn test_switch_model_to_mixedbread() {
         "Manifest should now have Mixedbread model"
     );
 }
+
+/// Writing to a closed pipe (`ck pattern | head`) must terminate ck silently
+/// via SIGPIPE (exit status 141), matching grep — not panic with a
+/// "failed printing to stdout: Broken pipe" message.
+#[cfg(unix)]
+#[test]
+fn test_sigpipe_terminates_silently() {
+    use std::io::Read;
+    use std::os::unix::process::ExitStatusExt;
+    use std::process::Stdio;
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // Enough matching output to overflow the OS pipe buffer after the read
+    // end closes (pipe buffers are typically 64KB).
+    let line = "match: the quick brown fox jumps over the lazy dog\n";
+    fs::write(temp_dir.path().join("big.txt"), line.repeat(50_000)).unwrap();
+
+    let mut child = Command::new(ck_binary())
+        .args(["match", temp_dir.path().to_str().unwrap()])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn ck");
+
+    // Read a little, then close the read end like `head` does.
+    let mut stdout = child.stdout.take().unwrap();
+    let mut buf = [0u8; 4096];
+    let _ = stdout.read(&mut buf).unwrap();
+    drop(stdout);
+
+    let status = child.wait().expect("Failed to wait on ck");
+    let mut stderr_out = String::new();
+    child
+        .stderr
+        .take()
+        .unwrap()
+        .read_to_string(&mut stderr_out)
+        .unwrap();
+
+    assert!(
+        !stderr_out.contains("panicked"),
+        "ck panicked on broken pipe: {stderr_out}"
+    );
+    assert_eq!(
+        status.signal(),
+        Some(libc::SIGPIPE),
+        "ck should be terminated by SIGPIPE, got status {status:?}"
+    );
+}


### PR DESCRIPTION
## Problem

`ck pattern file | head` — the most common grep idiom — panics:

```
thread 'main' panicked at library/std/src/io/stdio.rs:1165:9:
failed printing to stdout: Broken pipe (os error 32)
```

Rust's runtime ignores SIGPIPE by default, which turns EPIPE into a panic inside `println!` once the read end of the pipe closes.

## Fix

Restore SIGPIPE's default disposition on Unix at startup (`libc::signal(SIGPIPE, SIG_DFL)`), so ck terminates silently with status 141 — exactly what grep does. No-op on Windows.

## Testing

- New integration test `test_sigpipe_terminates_silently`: spawns ck with enough output to overflow the pipe buffer, closes the read end like `head`, asserts termination by SIGPIPE with no panic on stderr.
- Red-green verified: test fails with the `reset_sigpipe()` call removed.
- `cargo clippy --workspace --all-features --all-targets` clean, `cargo fmt` applied.

Also logs this + two other dogfooding findings in UNEXPECTED.md (index_size_bytes and semantic relevance entries remain Open; fixes coming separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)