### PR TITLE
fix(mcp): report real index size and separate indexing time from search time

### DIFF
--- a/ck-cli/src/lib.rs
+++ b/ck-cli/src/lib.rs
@@ -6,4 +6,6 @@ pub mod path_utils;
 // TUI is now in its own crate: ck-tui
 
 // Re-export commonly used types for testing
-pub use mcp_server::{CkMcpServer, HybridSearchRequest, RegexSearchRequest, SemanticSearchRequest};
+pub use mcp_server::{
+    CkMcpServer, HybridSearchRequest, IndexStatusRequest, RegexSearchRequest, SemanticSearchRequest,
+};

--- a/ck-cli/src/mcp/cache.rs
+++ b/ck-cli/src/mcp/cache.rs
@@ -8,20 +8,10 @@ use tokio::sync::RwLock;
 // Currently, search functions create embedders internally via ck_embed::create_embedder().
 // Future optimization: expose search APIs that accept pre-created embedders for true caching.
 
-/// Cache for index statistics with TTL
-#[derive(Debug, Clone)]
-pub struct IndexStats {
-    #[allow(dead_code)]
-    pub file_count: usize,
-    #[allow(dead_code)]
-    pub chunk_count: usize,
-    #[allow(dead_code)]
-    pub model_name: String,
-    #[allow(dead_code)]
-    pub last_updated: SystemTime,
-    #[allow(dead_code)]
-    pub is_valid: bool,
-}
+/// Cache for index statistics with TTL. Stores the full `ck_index::IndexStats`
+/// so cache hits report the same fields as fresh reads (chunk counts, embedded
+/// chunk counts, on-disk index size).
+pub use ck_index::IndexStats;
 
 #[derive(Clone)]
 pub struct StatsCache {

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -523,6 +523,7 @@ impl CkMcpServer {
         mode: &str,
         search_params: serde_json::Value,
         search_time_ms: u64,
+        index_update: Option<&ck_engine::IndexUpdate>,
     ) -> serde_json::Value {
         let results: Vec<serde_json::Value> = page.matches.iter().map(|result| {
             let match_type = format!("{mode}_match");
@@ -575,7 +576,15 @@ impl CkMcpServer {
                 "current_page": page.current_page
             },
             "metadata": {
+                // Time spent searching, excluding any automatic index update
+                // (see "indexing" for that).
                 "search_time_ms": search_time_ms,
+                "indexing": index_update.map(|u| json!({
+                    "triggered": u.did_work(),
+                    "files_indexed": u.files_indexed,
+                    "orphaned_files_removed": u.orphaned_files_removed,
+                    "duration_ms": u.duration_ms,
+                })),
                 "index_stats": null  // TODO: Add index information
             }
         })
@@ -608,7 +617,8 @@ impl CkMcpServer {
         let query = request.get_query();
         let search_params = request.get_search_params();
 
-        let structured_result = Self::search_page_to_json(page, &query, &mode, search_params, 0);
+        let structured_result =
+            Self::search_page_to_json(page, &query, &mode, search_params, 0, None);
 
         let summary = format!(
             "Retrieved page {} of {} search results for '{}'",
@@ -1101,7 +1111,7 @@ impl CkMcpServer {
         let mut indexing_progress_callback = indexing_progress_callback;
         let mut effective_mode: Option<String> = None;
         let started = Instant::now();
-        let search_results = match ck_engine::search_enhanced_with_indexing_progress(
+        let (search_results, index_update) = match ck_engine::search_enhanced_with_outcome(
             &options,
             None,
             indexing_progress_callback.take(),
@@ -1109,7 +1119,7 @@ impl CkMcpServer {
         )
         .await
         {
-            Ok(results) => results,
+            Ok(outcome) => (outcome.results, outcome.index_update),
             Err(e) => {
                 let message = e.to_string();
                 if message.contains("No embeddings found") {
@@ -1119,7 +1129,7 @@ impl CkMcpServer {
                     );
                     let mut reindex_options = options.clone();
                     reindex_options.reindex = true;
-                    match ck_engine::search_enhanced_with_indexing_progress(
+                    match ck_engine::search_enhanced_with_outcome(
                         &reindex_options,
                         None,
                         None,
@@ -1127,14 +1137,14 @@ impl CkMcpServer {
                     )
                     .await
                     {
-                        Ok(results) => results,
+                        Ok(outcome) => (outcome.results, outcome.index_update),
                         Err(retry_err) => {
                             tracing::warn!("semantic search failed after reindex: {}", retry_err);
                             // Fallback to lexical search when embeddings are unavailable
                             let mut fallback_options = options.clone();
                             fallback_options.mode = SearchMode::Lexical;
                             fallback_options.reindex = true;
-                            match ck_engine::search_enhanced_with_indexing_progress(
+                            match ck_engine::search_enhanced_with_outcome(
                                 &fallback_options,
                                 None,
                                 None,
@@ -1142,7 +1152,8 @@ impl CkMcpServer {
                             )
                             .await
                             {
-                                Ok(mut lexical_results) => {
+                                Ok(outcome) => {
+                                    let mut lexical_results = outcome.results;
                                     if let Some(limit) = top_k {
                                         lexical_results
                                             .matches
@@ -1150,7 +1161,7 @@ impl CkMcpServer {
                                     }
                                     effective_mode =
                                         Some("semantic (lexical fallback)".to_string());
-                                    lexical_results
+                                    (lexical_results, outcome.index_update)
                                 }
                                 Err(final_err) => {
                                     return Err(ErrorData::internal_error(
@@ -1167,7 +1178,8 @@ impl CkMcpServer {
                 }
             }
         };
-        let elapsed_ms = started.elapsed().as_millis() as u64;
+        let elapsed_ms = (started.elapsed().as_millis() as u64)
+            .saturating_sub(index_update.as_ref().map_or(0, |u| u.duration_ms));
 
         // Create session and get first page
         let page = self
@@ -1187,8 +1199,14 @@ impl CkMcpServer {
         });
 
         let current_page = page.current_page;
-        let mut structured_result =
-            Self::search_page_to_json(page, &query_clone, "semantic", search_params, elapsed_ms);
+        let mut structured_result = Self::search_page_to_json(
+            page,
+            &query_clone,
+            "semantic",
+            search_params,
+            elapsed_ms,
+            index_update.as_ref(),
+        );
 
         if let Some(ref note) = effective_mode
             && let Some(metadata) = structured_result.get_mut("metadata")
@@ -1296,14 +1314,13 @@ impl CkMcpServer {
         };
 
         let started = Instant::now();
-        let search_results =
-            match ck_engine::search_enhanced_with_indexing_progress(&options, None, None, None)
-                .await
-            {
-                Ok(results) => results,
+        let (search_results, index_update) =
+            match ck_engine::search_enhanced_with_outcome(&options, None, None, None).await {
+                Ok(outcome) => (outcome.results, outcome.index_update),
                 Err(e) => return Err(ErrorData::internal_error(e.to_string(), None)),
             };
-        let elapsed_ms = started.elapsed().as_millis() as u64;
+        let elapsed_ms = (started.elapsed().as_millis() as u64)
+            .saturating_sub(index_update.as_ref().map_or(0, |u| u.duration_ms));
 
         let page = self
             .context
@@ -1322,8 +1339,14 @@ impl CkMcpServer {
         });
 
         let current_page = page.current_page;
-        let structured_result =
-            Self::search_page_to_json(page, &query_clone, "lexical", search_params, elapsed_ms);
+        let structured_result = Self::search_page_to_json(
+            page,
+            &query_clone,
+            "lexical",
+            search_params,
+            elapsed_ms,
+            index_update.as_ref(),
+        );
 
         let summary = format!(
             "Lexical search for '{}' found {} matches in {} (top_k: {}, threshold: {}) - Page {}",
@@ -1454,8 +1477,14 @@ impl CkMcpServer {
             "context_lines": context.unwrap_or(0)
         });
 
-        let structured_result =
-            Self::search_page_to_json(page, &pattern_clone, "regex", search_params, elapsed_ms);
+        let structured_result = Self::search_page_to_json(
+            page,
+            &pattern_clone,
+            "regex",
+            search_params,
+            elapsed_ms,
+            None, // regex mode never touches the index
+        );
 
         let summary = format!(
             "Regex search for pattern '{}' found {} matches in {} (case_sensitive: {}, context: {} lines) - Page 1",
@@ -1553,17 +1582,18 @@ impl CkMcpServer {
 
         // Perform the search (suppress progress callbacks for MCP)
         let started = Instant::now();
-        let search_results = match ck_engine::search_enhanced_with_indexing_progress(
+        let (search_results, index_update) = match ck_engine::search_enhanced_with_outcome(
             &options, None, // No search progress callback for MCP
             None, // No indexing progress callback for MCP
             None, // No detailed indexing progress callback for MCP
         )
         .await
         {
-            Ok(results) => results,
+            Ok(outcome) => (outcome.results, outcome.index_update),
             Err(e) => return Err(ErrorData::internal_error(e.to_string(), None)),
         };
-        let elapsed_ms = started.elapsed().as_millis() as u64;
+        let elapsed_ms = (started.elapsed().as_millis() as u64)
+            .saturating_sub(index_update.as_ref().map_or(0, |u| u.duration_ms));
 
         // Create session and get first page
         let page = self
@@ -1583,8 +1613,14 @@ impl CkMcpServer {
         });
 
         let current_page = page.current_page;
-        let structured_result =
-            Self::search_page_to_json(page, &query_clone, "hybrid", search_params, elapsed_ms);
+        let structured_result = Self::search_page_to_json(
+            page,
+            &query_clone,
+            "hybrid",
+            search_params,
+            elapsed_ms,
+            index_update.as_ref(),
+        );
 
         let summary = format!(
             "Hybrid search for '{}' found {} matches in {} (threshold: {:.3}, top_k: {}, combines semantic + regex) - Page {}",
@@ -1599,7 +1635,7 @@ impl CkMcpServer {
         Ok((summary, structured_result))
     }
 
-    async fn handle_index_status(
+    pub async fn handle_index_status(
         &self,
         request: IndexStatusRequest,
         _meta: Option<Meta>,
@@ -1624,9 +1660,7 @@ impl CkMcpServer {
         });
 
         if index_exists {
-            // Try to get more detailed information about the index
             if let Ok(metadata) = std::fs::metadata(&index_path) {
-                index_info["index_size_bytes"] = json!(metadata.len());
                 index_info["last_modified"] = json!(
                     metadata
                         .modified()
@@ -1639,16 +1673,34 @@ impl CkMcpServer {
             }
 
             // Get detailed index statistics using ck_index with caching
-            if let Some(cached_stats) = self.context.stats_cache.get(&path_buf).await {
-                index_info["total_files"] = json!(cached_stats.file_count);
-                index_info["total_chunks"] = json!(cached_stats.chunk_count);
+            let index_stats = if let Some(cached) = self.context.stats_cache.get(&path_buf).await {
                 index_info["cache_hit"] = json!(true);
-            } else if let Ok(index_stats) = ck_index::get_index_stats(&path_buf) {
-                index_info["total_files"] = json!(index_stats.total_files);
-                index_info["total_chunks"] = json!(index_stats.total_chunks);
-                index_info["embedded_chunks"] = json!(index_stats.embedded_chunks);
-                index_info["total_size_bytes"] = json!(index_stats.total_size_bytes);
+                Some(cached)
+            } else if let Ok(fresh) = ck_index::get_index_stats(&path_buf) {
                 index_info["cache_hit"] = json!(false);
+                self.context
+                    .stats_cache
+                    .update(path_buf.clone(), fresh.clone())
+                    .await;
+                Some(fresh)
+            } else {
+                None
+            };
+
+            if let Some(stats) = index_stats {
+                index_info["total_files"] = json!(stats.total_files);
+                index_info["total_chunks"] = json!(stats.total_chunks);
+                index_info["embedded_chunks"] = json!(stats.embedded_chunks);
+                // Chunks indexed but not yet embedded (e.g. index built without
+                // embeddings, or interrupted embedding pass). Semantic search
+                // only sees embedded chunks.
+                index_info["chunks_pending_embedding"] =
+                    json!(stats.total_chunks.saturating_sub(stats.embedded_chunks));
+                // Combined size of the indexed source files
+                index_info["total_size_bytes"] = json!(stats.total_size_bytes);
+                // On-disk size of the .ck directory itself (sidecars, manifest,
+                // caches) — previously misreported as the directory entry size
+                index_info["index_size_bytes"] = json!(stats.index_size_bytes);
 
                 // Add model information if available
                 let manifest_path = path_buf.join(".ck").join("manifest.json");
@@ -1680,19 +1732,6 @@ impl CkMcpServer {
                         "dimensions": dims,
                     });
                 }
-
-                // Update cache with fresh stats
-                let cache_stats = crate::mcp::cache::IndexStats {
-                    file_count: index_stats.total_files,
-                    chunk_count: index_stats.total_chunks,
-                    model_name: "unknown".to_string(), // TODO: Get from manifest
-                    last_updated: std::time::SystemTime::now(),
-                    is_valid: true,
-                };
-                self.context
-                    .stats_cache
-                    .update(path_buf.clone(), cache_stats)
-                    .await;
             } else {
                 // Fallback: Count files in directory for estimation
                 let file_count = WalkDir::new(&path_buf)

--- a/ck-cli/tests/mcp_tests.rs
+++ b/ck-cli/tests/mcp_tests.rs
@@ -380,3 +380,101 @@ async fn test_mcp_semantic_search_with_missing_files() {
         assert!(summary.contains("top_k: 20"));
     }
 }
+
+#[tokio::test]
+async fn test_mcp_index_status_reports_real_index_size() {
+    use ck_search::IndexStatusRequest;
+
+    let temp_dir = create_test_files().await;
+    let server = CkMcpServer::new(temp_dir.path().to_path_buf()).unwrap();
+
+    // Build the index by running a semantic search first (auto-indexes)
+    let search = SemanticSearchRequest {
+        query: "error handling".to_string(),
+        path: temp_dir.path().to_string_lossy().to_string(),
+        threshold: Some(0.0),
+        ..Default::default()
+    };
+    server
+        .handle_semantic_search(search, None, None)
+        .await
+        .expect("semantic search should succeed");
+
+    let request = IndexStatusRequest {
+        path: temp_dir.path().to_string_lossy().to_string(),
+    };
+    let (_, response) = server
+        .handle_index_status(request, None, None)
+        .await
+        .expect("index_status should succeed");
+
+    let info = &response["index_status"];
+    assert_eq!(info["index_exists"], true);
+
+    // index_size_bytes must be the recursive on-disk size of .ck, not the
+    // directory entry's own size. Compare against an independent walk.
+    let expected_size: u64 = walkdir::WalkDir::new(temp_dir.path().join(".ck"))
+        .into_iter()
+        .filter_map(Result::ok)
+        .filter(|e| e.file_type().is_file())
+        .filter_map(|e| e.metadata().ok())
+        .map(|m| m.len())
+        .sum();
+    assert!(expected_size > 0, "test setup: index should not be empty");
+    assert_eq!(info["index_size_bytes"], expected_size);
+
+    // Chunk accounting must be present and consistent
+    let total = info["total_chunks"].as_u64().unwrap();
+    let embedded = info["embedded_chunks"].as_u64().unwrap();
+    let pending = info["chunks_pending_embedding"].as_u64().unwrap();
+    assert_eq!(pending, total - embedded);
+}
+
+#[tokio::test]
+async fn test_mcp_search_time_excludes_indexing_and_reports_it() {
+    let temp_dir = create_test_files().await;
+    let server = CkMcpServer::new(temp_dir.path().to_path_buf()).unwrap();
+
+    let request = || SemanticSearchRequest {
+        query: "error handling".to_string(),
+        path: temp_dir.path().to_string_lossy().to_string(),
+        threshold: Some(0.0),
+        ..Default::default()
+    };
+
+    // First search on an unindexed directory triggers auto-indexing,
+    // which must be reported separately from search time.
+    let (_, response) = server
+        .handle_semantic_search(request(), None, None)
+        .await
+        .expect("semantic search should succeed");
+    let indexing = &response["metadata"]["indexing"];
+    assert!(
+        indexing.is_object(),
+        "semantic search should report indexing metadata, got: {indexing}"
+    );
+    assert_eq!(indexing["triggered"], true);
+    assert!(indexing["files_indexed"].as_u64().unwrap() > 0);
+    assert!(response["metadata"]["search_time_ms"].is_number());
+
+    // Second search finds a fresh index: the staleness check runs but no work
+    let (_, response) = server
+        .handle_semantic_search(request(), None, None)
+        .await
+        .expect("semantic search should succeed");
+    let indexing = &response["metadata"]["indexing"];
+    assert_eq!(indexing["triggered"], false);
+    assert_eq!(indexing["files_indexed"], 0);
+
+    // Regex search never touches the index
+    let regex_request = RegexSearchRequest {
+        pattern: "function".to_string(),
+        path: temp_dir.path().to_string_lossy().to_string(),
+        ..Default::default()
+    };
+    let (_, response) = server
+        .handle_regex_search(regex_request)
+        .await
+        .expect("regex search should succeed");
+    assert!(response["metadata"]["indexing"].is_null());
+}

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -322,12 +322,55 @@ pub async fn search_enhanced_with_progress(
 }
 
 /// Enhanced search with both search and indexing progress callbacks
+/// Summary of index maintenance performed automatically before a search.
+#[derive(Debug, Clone, Default)]
+pub struct IndexUpdate {
+    pub files_indexed: usize,
+    pub orphaned_files_removed: usize,
+    /// Wall-clock time spent checking and updating the index, in milliseconds.
+    /// This covers the staleness check even when no files needed work.
+    pub duration_ms: u64,
+}
+
+impl IndexUpdate {
+    /// True when the index actually changed (files re-indexed or removed),
+    /// as opposed to a no-op staleness check.
+    pub fn did_work(&self) -> bool {
+        self.files_indexed > 0 || self.orphaned_files_removed > 0
+    }
+}
+
+/// Search results plus what auto-indexing did to produce them, so callers can
+/// report search latency separately from index-build latency.
+#[derive(Debug)]
+pub struct SearchOutcome {
+    pub results: ck_core::SearchResults,
+    /// `None` for regex mode (which never touches the index).
+    pub index_update: Option<IndexUpdate>,
+}
+
 pub async fn search_enhanced_with_indexing_progress(
     options: &SearchOptions,
     progress_callback: Option<SearchProgressCallback>,
     indexing_progress_callback: Option<IndexingProgressCallback>,
     detailed_indexing_progress_callback: Option<DetailedIndexingProgressCallback>,
 ) -> Result<ck_core::SearchResults> {
+    let outcome = search_enhanced_with_outcome(
+        options,
+        progress_callback,
+        indexing_progress_callback,
+        detailed_indexing_progress_callback,
+    )
+    .await?;
+    Ok(outcome.results)
+}
+
+pub async fn search_enhanced_with_outcome(
+    options: &SearchOptions,
+    progress_callback: Option<SearchProgressCallback>,
+    indexing_progress_callback: Option<IndexingProgressCallback>,
+    detailed_indexing_progress_callback: Option<DetailedIndexingProgressCallback>,
+) -> Result<SearchOutcome> {
     // Validate that the search path exists
     if !options.path.exists() {
         return Err(ck_core::CkError::Search(format!(
@@ -338,10 +381,12 @@ pub async fn search_enhanced_with_indexing_progress(
     }
 
     // Auto-update index if needed (unless it's regex-only mode)
+    let mut index_update = None;
     if !matches!(options.mode, SearchMode::Regex) {
         let need_embeddings = matches!(options.mode, SearchMode::Semantic | SearchMode::Hybrid);
         let file_options = ck_core::FileCollectionOptions::from(options);
-        ensure_index_updated_with_progress(
+        let started = std::time::Instant::now();
+        let update_stats = ensure_index_updated_with_progress(
             &options.path,
             options.reindex,
             need_embeddings,
@@ -351,6 +396,17 @@ pub async fn search_enhanced_with_indexing_progress(
             options.embedding_model.as_deref(),
         )
         .await?;
+        index_update = Some(IndexUpdate {
+            files_indexed: update_stats
+                .as_ref()
+                .map(|s| s.files_indexed)
+                .unwrap_or_default(),
+            orphaned_files_removed: update_stats
+                .as_ref()
+                .map(|s| s.orphaned_files_removed)
+                .unwrap_or_default(),
+            duration_ms: started.elapsed().as_millis() as u64,
+        });
     }
 
     let search_results = match options.mode {
@@ -381,7 +437,10 @@ pub async fn search_enhanced_with_indexing_progress(
         }
     };
 
-    Ok(search_results)
+    Ok(SearchOutcome {
+        results: search_results,
+        index_update,
+    })
 }
 
 fn regex_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
@@ -1143,6 +1202,8 @@ fn collect_files(
     Ok(files)
 }
 
+/// Returns the indexing stats when a directory-level smart update ran, or
+/// `None` for the single-file fast path (which reports no stats).
 async fn ensure_index_updated_with_progress(
     path: &Path,
     force_reindex: bool,
@@ -1151,7 +1212,7 @@ async fn ensure_index_updated_with_progress(
     detailed_progress_callback: Option<ck_index::DetailedProgressCallback>,
     file_options: &ck_core::FileCollectionOptions,
     model_override: Option<&str>,
-) -> Result<()> {
+) -> Result<Option<ck_index::UpdateStats>> {
     // Find index root for .ck directory location
     let index_root_buf = find_nearest_index_root(path).unwrap_or_else(|| {
         if path.is_file() {
@@ -1182,7 +1243,7 @@ async fn ensure_index_updated_with_progress(
                 stats.orphaned_files_removed
             );
         }
-        return Ok(());
+        return Ok(Some(stats));
     }
 
     // For incremental updates with individual files, we need special handling
@@ -1191,6 +1252,7 @@ async fn ensure_index_updated_with_progress(
         // Index just this one file
         use ck_index::index_file;
         index_file(path, need_embeddings).await?;
+        Ok(None)
     } else {
         // For directories, use the standard smart update
         let stats = ck_index::smart_update_index_with_detailed_progress(
@@ -1210,9 +1272,8 @@ async fn ensure_index_updated_with_progress(
                 stats.orphaned_files_removed
             );
         }
+        Ok(Some(stats))
     }
-
-    Ok(())
 }
 
 fn get_context_preview(lines: &[String], line_idx: usize, options: &SearchOptions) -> String {


### PR DESCRIPTION
## Problem (found while dogfooding the MCP server)

Two metrics in MCP responses were untrustworthy:

1. **`index_size_bytes: 928`** for an index with 1,825 embedded chunks — `fs::metadata(.ck).len()` returns the *directory entry's* size, not the index. The correct recursive size was already computed in `ck_index::get_index_stats` and never used.
2. **`search_time_ms: 1839209`** (~30 min) for a search that should take ~1s. The timer wrapped `search_enhanced_with_indexing_progress`, which silently includes auto-indexing — a stale index makes a fast search report as a glacial one, and the agent can't tell why.

Also: `embedded_chunks` (1825) vs `total_chunks` (1970) had no field explaining the gap, and stats-cache hits dropped `embedded_chunks`/size/model fields entirely.

## Changes

**ck-engine**: new `search_enhanced_with_outcome` returning `SearchOutcome { results, index_update }`, where `IndexUpdate` carries files indexed, orphans removed, and time spent on index maintenance. Existing `search_enhanced_with_indexing_progress` is now a thin wrapper — no caller changes needed elsewhere.

**MCP server**:
- `search_time_ms` now excludes index maintenance; a new `metadata.indexing` block reports `{triggered, files_indexed, orphaned_files_removed, duration_ms}` (`null` for regex mode, which never indexes).
- `index_status` reports the real recursive `.ck` size, adds `chunks_pending_embedding`, and the stats cache now stores full `ck_index::IndexStats` so cache hits report the same fields as misses (including model info).

## Testing

- New `test_mcp_index_status_reports_real_index_size` — compares `index_size_bytes` against an independent walk of `.ck`, checks chunk accounting consistency.
- New `test_mcp_search_time_excludes_indexing_and_reports_it` — first search on unindexed dir reports `indexing.triggered: true`, second reports `false`, regex reports `null`.
- `cargo test -p ck-engine -p ck-search` green; clippy clean (the only warnings are pre-existing ck-embed example lints under no-default-features); `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)