### PR TITLE
fix(ck-index): cross-process write lock on the index directory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -495,6 +495,7 @@ dependencies = [
  "ck-embed",
  "ck-models",
  "ctrlc",
+ "fs4 0.13.1",
  "ignore",
  "memmap2",
  "pdf-extract",
@@ -1226,6 +1227,16 @@ checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
 dependencies = [
  "rustix 0.38.44",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3494,7 +3505,7 @@ dependencies = [
  "downcast-rs",
  "fastdivide",
  "fnv",
- "fs4",
+ "fs4 0.8.4",
  "htmlescape",
  "hyperloglogplus",
  "itertools 0.14.0",
@@ -3629,7 +3640,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 rayon = "1.12"
 walkdir = "2.4"
+fs4 = "0.13"
 tantivy = "0.24"
 tree-sitter = "0.25"
 tree-sitter-python = "0.25"

--- a/UNEXPECTED.md
+++ b/UNEXPECTED.md
@@ -41,6 +41,15 @@ This file tracks instances where ck behaves unexpectedly during testing or usage
 
 ---
 
+**Command:** `ck --index /some/other/dir` (from inside a different directory)
+**Expected:** Indexes `/some/other/dir` ("Create or update search index for the specified path")
+**Actual:** The path argument lands in the positional *pattern* slot, `files` stays empty, and ck indexes the **current working directory** instead. `ck --index .` only works by coincidence (the "." pattern is ignored and "." is also the default path). Likely the same root cause as the `ck --add /tmp/test.txt` entry above.
+**Date:** 2026-06-10
+**Status:** Open
+**Notes:** Found while writing a concurrent-indexing test: two `ck --index <tempdir>` processes silently indexed the ck repo itself (cwd). Command-mode flags (`--index`, `--clean`, `--add`, …) should treat the first positional arg as their target path.
+
+---
+
 ## Instructions
 
 When you encounter unexpected behavior while using ck:

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -1069,3 +1069,59 @@ fn test_switch_model_to_mixedbread() {
         "Manifest should now have Mixedbread model"
     );
 }
+
+/// Two ck processes indexing the same directory concurrently must serialize
+/// on the index write lock instead of interleaving manifest writes. Both
+/// should succeed and the final manifest should contain every file.
+#[test]
+fn test_concurrent_indexing_is_serialized() {
+    use std::process::Stdio;
+
+    let temp_dir = TempDir::new().unwrap();
+    let file_count = 30;
+    for i in 0..file_count {
+        fs::write(
+            temp_dir.path().join(format!("file{i}.txt")),
+            format!("searchable content number {i}\n").repeat(50),
+        )
+        .unwrap();
+    }
+
+    // Note: `--index` resolves its target from the positional pattern slot,
+    // so an explicit path argument would be misparsed (see UNEXPECTED.md).
+    // Run from inside the directory instead.
+    let spawn_indexer = || {
+        Command::new(ck_binary())
+            .arg("--index")
+            .current_dir(temp_dir.path())
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("Failed to spawn ck --index")
+    };
+
+    let first = spawn_indexer();
+    let second = spawn_indexer();
+
+    for child in [first, second] {
+        let output = child.wait_with_output().expect("Failed to wait on ck");
+        assert!(
+            output.status.success(),
+            "concurrent ck --index failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let manifest_data =
+        fs::read(temp_dir.path().join(".ck").join("manifest.json")).expect("manifest must exist");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&manifest_data).expect("manifest must be valid JSON");
+    let files = manifest["files"]
+        .as_object()
+        .expect("manifest.files object");
+    assert_eq!(
+        files.len(),
+        file_count,
+        "manifest lost entries under concurrent indexing"
+    );
+}

--- a/ck-index/Cargo.toml
+++ b/ck-index/Cargo.toml
@@ -25,6 +25,7 @@ memmap2 = { workspace = true }
 tokio = { workspace = true }
 rayon = { workspace = true }
 walkdir = { workspace = true }
+fs4 = { workspace = true }
 tracing = { workspace = true }
 ignore = { workspace = true }
 ctrlc = { workspace = true }

--- a/ck-index/src/lib.rs
+++ b/ck-index/src/lib.rs
@@ -248,7 +248,56 @@ fn collect_files_as_hashset(
     Ok(collect_files(path, options)?.into_iter().collect())
 }
 
+/// Name of the advisory lock file inside `.ck`, guarding against concurrent
+/// writers (two `ck` processes indexing the same directory would otherwise
+/// interleave manifest writes and silently lose each other's entries).
+const INDEX_LOCK_FILE: &str = ".lock";
+
+/// Held for the duration of any index mutation. The OS advisory lock is
+/// released when this is dropped (the file handle closes).
+///
+/// Readers take no lock: every manifest and sidecar write goes through
+/// `atomic_write` (temp file + rename), so a reader can never observe a
+/// partially written file — only writers conflict with writers.
+struct IndexWriteLock {
+    _file: std::fs::File,
+}
+
+/// Acquire an exclusive cross-process lock on the index directory, creating
+/// the directory if needed. Blocks (with a log message) if another process
+/// holds the lock.
+fn acquire_index_write_lock(index_dir: &Path) -> Result<IndexWriteLock> {
+    use fs4::fs_std::FileExt;
+
+    fs::create_dir_all(index_dir)?;
+    let lock_path = index_dir.join(INDEX_LOCK_FILE);
+    let file = fs::OpenOptions::new()
+        .create(true)
+        .truncate(false)
+        .write(true)
+        .open(&lock_path)?;
+    if !file.try_lock_exclusive()? {
+        tracing::info!(
+            "Index {} is locked by another ck process; waiting for it to finish",
+            index_dir.display()
+        );
+        file.lock_exclusive()?;
+    }
+    Ok(IndexWriteLock { _file: file })
+}
+
 pub async fn index_directory(
+    path: &Path,
+    compute_embeddings: bool,
+    options: &ck_core::FileCollectionOptions,
+    model: Option<&str>,
+) -> Result<()> {
+    let _lock = acquire_index_write_lock(&path.join(".ck"))?;
+    index_directory_inner(path, compute_embeddings, options, model).await
+}
+
+/// Body of [`index_directory`]; callers must hold the index write lock.
+async fn index_directory_inner(
     path: &Path,
     compute_embeddings: bool,
     options: &ck_core::FileCollectionOptions,
@@ -403,7 +452,7 @@ pub async fn index_directory(
 pub async fn index_file(file_path: &Path, compute_embeddings: bool) -> Result<()> {
     let repo_root = find_repo_root(file_path)?;
     let index_dir = repo_root.join(".ck");
-    fs::create_dir_all(&index_dir)?;
+    let _lock = acquire_index_write_lock(&index_dir)?;
 
     let manifest_path = index_dir.join("manifest.json");
     let mut manifest = load_or_create_manifest(&manifest_path)?;
@@ -454,8 +503,10 @@ pub async fn update_index(
     options: &ck_core::FileCollectionOptions,
 ) -> Result<()> {
     let index_dir = path.join(".ck");
-    if !index_dir.exists() {
-        return index_directory(
+    let index_existed = index_dir.exists();
+    let _lock = acquire_index_write_lock(&index_dir)?;
+    if !index_existed {
+        return index_directory_inner(
             path,
             compute_embeddings,
             options,
@@ -592,8 +643,34 @@ pub async fn update_index(
 
 pub fn clean_index(path: &Path) -> Result<()> {
     let index_dir = path.join(".ck");
-    if index_dir.exists() {
-        fs::remove_dir_all(&index_dir)?;
+    if !index_dir.exists() {
+        return Ok(());
+    }
+    let lock = acquire_index_write_lock(&index_dir)?;
+    clean_index_inner(&index_dir)?;
+    drop(lock);
+    // Best-effort: remove the lock file and the now-empty directory. If a
+    // concurrent process re-acquired the lock in the meantime, removal fails
+    // and we leave the directory to it (it is rebuilding the index anyway).
+    let _ = fs::remove_file(index_dir.join(INDEX_LOCK_FILE));
+    let _ = fs::remove_dir(&index_dir);
+    Ok(())
+}
+
+/// Remove all index contents except the lock file (which the caller holds
+/// open — deleting an open locked file would fail on Windows).
+fn clean_index_inner(index_dir: &Path) -> Result<()> {
+    for entry in fs::read_dir(index_dir)? {
+        let entry = entry?;
+        if entry.file_name().to_str() == Some(INDEX_LOCK_FILE) {
+            continue;
+        }
+        let entry_path = entry.path();
+        if entry.file_type()?.is_dir() {
+            fs::remove_dir_all(&entry_path)?;
+        } else {
+            fs::remove_file(&entry_path)?;
+        }
     }
     Ok(())
 }
@@ -606,6 +683,7 @@ pub fn cleanup_index(
     if !index_dir.exists() {
         return Ok(CleanupStats::default());
     }
+    let _lock = acquire_index_write_lock(&index_dir)?;
 
     let manifest_path = index_dir.join("manifest.json");
     let mut manifest = load_or_create_manifest(&manifest_path)?;
@@ -734,6 +812,7 @@ pub async fn smart_update_index_with_detailed_progress(
     model: Option<&str>,
 ) -> Result<UpdateStats> {
     let index_dir = path.join(".ck");
+    let _lock = acquire_index_write_lock(&index_dir)?;
     let mut stats = UpdateStats::default();
 
     // Set up interrupt handler (only once per process)
@@ -748,8 +827,10 @@ pub async fn smart_update_index_with_detailed_progress(
     INTERRUPTED.store(false, Ordering::SeqCst);
 
     if force_rebuild {
-        clean_index(path)?;
-        index_directory(path, compute_embeddings, options, model).await?;
+        // Use the unlocked variants: we already hold the index write lock,
+        // and a second acquisition on a fresh handle would self-deadlock.
+        clean_index_inner(&index_dir)?;
+        index_directory_inner(path, compute_embeddings, options, model).await?;
         let index_stats = get_index_stats(path)?;
         stats.files_indexed = index_stats.total_files;
         return Ok(stats);
@@ -1908,6 +1989,49 @@ mod tests {
         // Check that manifest was updated
         let updated_manifest = load_or_create_manifest(&manifest_path).unwrap();
         assert_eq!(updated_manifest.files.len(), 0);
+    }
+
+    #[test]
+    fn test_index_write_lock_blocks_concurrent_writer() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let temp_dir = TempDir::new().unwrap();
+        let index_dir = temp_dir.path().join(".ck");
+
+        let lock = acquire_index_write_lock(&index_dir).unwrap();
+        let released = Arc::new(AtomicBool::new(false));
+
+        let dir = index_dir.clone();
+        let released_flag = released.clone();
+        let waiter = std::thread::spawn(move || {
+            let _lock = acquire_index_write_lock(&dir).unwrap();
+            assert!(
+                released_flag.load(Ordering::SeqCst),
+                "second writer acquired the index lock while the first still held it"
+            );
+        });
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+        released.store(true, Ordering::SeqCst);
+        drop(lock);
+        waiter.join().unwrap();
+    }
+
+    #[test]
+    fn test_clean_index_removes_index_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_path = temp_dir.path();
+        let index_dir = test_path.join(".ck");
+        fs::create_dir_all(index_dir.join("sub")).unwrap();
+        fs::write(index_dir.join("manifest.json"), "{}").unwrap();
+        fs::write(index_dir.join("sub").join("file.rs.ck"), "x").unwrap();
+
+        clean_index(test_path).unwrap();
+        assert!(
+            !index_dir.exists(),
+            "clean_index should remove the .ck directory entirely"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Problem

Nothing prevented two ck processes from mutating the same `.ck` index concurrently — two `ck --index` runs, or parallel agent invocations both triggering auto-indexing. Each process writes `manifest.json` after every file, so concurrent writers interleave and silently lose each other's entries. (The MCP server has in-process lock machinery, but it's per-process and mostly dead code — it never covered the CLI or multiple servers.)

For ck's core audience — agents that routinely run in parallel — this is the most likely real-world corruption path.

## Fix

Advisory cross-process file lock at `.ck/.lock` (via `fs4`: `flock` on Unix, `LockFileEx` on Windows), acquired by every mutating entry point:

- `index_directory`, `index_file`, `update_index`, `smart_update_index*` (the public delegation chain locks once at the innermost public fn), `cleanup_index`, `clean_index`
- A second writer **blocks** until the first finishes, with a `tracing::info` message — concurrent invocations serialize instead of corrupting.
- Internal nested calls (force-rebuild → clean + full index) use unlocked `_inner` variants to avoid self-deadlock.
- **Readers take no lock**: every write already goes through atomic temp-file + rename, so a reader can never observe a partial file; only writer/writer conflicts exist.
- `clean_index` empties the directory while holding the lock (deleting an open locked file fails on Windows), then best-effort removes the lock file + dir; if a racer re-acquired in between, the dir is left to them.
- The `.lock` file is invisible to sidecar walkers (they filter on the `.ck` extension) and to orphan cleanup.

## Testing

- `test_index_write_lock_blocks_concurrent_writer` — second acquisition blocks until the holder releases.
- `test_clean_index_removes_index_dir` — clean still removes `.ck` entirely.
- `test_concurrent_indexing_is_serialized` (integration) — two simultaneous `ck --index` processes both succeed and the manifest retains all 30 entries.
- Full `ck-index` + `ck-search` suites green; clippy clean; fmt applied.

## Drive-by

While writing the integration test, found that `ck --index <path>` misparses `<path>` as the search *pattern* and indexes the cwd instead (same root cause as the old `--add` entry). Documented in UNEXPECTED.md; fix coming as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)