### PR TITLE
fix(ck-cli): command-mode flags honor their explicit path argument

### DIFF
--- a/UNEXPECTED.md
+++ b/UNEXPECTED.md
@@ -71,7 +71,7 @@ This file tracks instances where ck behaves unexpectedly during testing or usage
 **Expected:** Indexes `/some/other/dir` ("Create or update search index for the specified path")
 **Actual:** The path argument lands in the positional *pattern* slot, `files` stays empty, and ck indexes the **current working directory** instead. `ck --index .` only works by coincidence (the "." pattern is ignored and "." is also the default path). Likely the same root cause as the `ck --add /tmp/test.txt` entry above.
 **Date:** 2026-06-10
-**Status:** Open
+**Status:** Fixed (fix/command-flag-paths — command-mode flags now resolve their target from the pattern slot via `Cli::command_target_path`; covers `--index`, `--clean`, `--clean-orphans`, `--status*`, `--switch-model`, `--add`)
 **Notes:** Found while writing a concurrent-indexing test: two `ck --index <tempdir>` processes silently indexed the ck repo itself (cwd). Command-mode flags (`--index`, `--clean`, `--add`, …) should treat the first positional arg as their target path.
 
 ---

--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -382,6 +382,21 @@ struct Cli {
     tui: bool,
 }
 
+impl Cli {
+    /// Target path for command-mode flags (`--index`, `--clean`, `--status`,
+    /// `--switch-model`, …). These commands take no search pattern, so a lone
+    /// positional argument (`ck --index /repo`) is parsed into the `pattern`
+    /// slot — previously it was silently ignored and the command ran against
+    /// the cwd. Explicit later positionals (`files`) win when both exist.
+    fn command_target_path(&self) -> PathBuf {
+        self.files
+            .first()
+            .cloned()
+            .or_else(|| self.pattern.as_ref().map(PathBuf::from))
+            .unwrap_or_else(|| PathBuf::from("."))
+    }
+}
+
 fn canonicalize_for_comparison(path: &Path) -> PathBuf {
     if let Ok(canonical) = path.canonicalize() {
         return canonical;
@@ -955,11 +970,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
 
     // Handle command flags first (these take precedence over search)
     if let Some(model_name) = cli.switch_model.as_deref() {
-        let path = cli
-            .files
-            .first()
-            .cloned()
-            .unwrap_or_else(|| PathBuf::from("."));
+        let path = cli.command_target_path();
 
         let registry = ck_models::ModelRegistry::default();
         let (model_alias, model_config) = registry
@@ -1015,11 +1026,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
     }
 
     if cli.index {
-        let path = cli
-            .files
-            .first()
-            .cloned()
-            .unwrap_or_else(|| PathBuf::from("."));
+        let path = cli.command_target_path();
 
         let registry = ck_models::ModelRegistry::default();
         let (model_alias, model_config) = registry
@@ -1041,11 +1048,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
 
     if cli.clean || cli.clean_orphans {
         // Handle --clean and --clean-orphans flags
-        let clean_path = cli
-            .files
-            .first()
-            .cloned()
-            .unwrap_or_else(|| PathBuf::from("."));
+        let clean_path = cli.command_target_path();
         let orphans_only = cli.clean_orphans;
 
         if orphans_only {
@@ -1092,25 +1095,12 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
 
     if cli.add {
         // Handle --add flag
-        // When using --add, the file path might be in pattern or files
-        let file = if let Some(ref pattern) = cli.pattern {
-            // If pattern is provided and no files, use pattern as the file path
-            if cli.files.is_empty() {
-                PathBuf::from(pattern)
-            } else {
-                // Otherwise use the first file
-                cli.files
-                    .first()
-                    .cloned()
-                    .ok_or_else(|| anyhow::anyhow!("No file specified. Usage: ck --add <file>"))?
-            }
-        } else {
-            // No pattern, must be in files
-            cli.files
-                .first()
-                .cloned()
-                .ok_or_else(|| anyhow::anyhow!("No file specified. Usage: ck --add <file>"))?
-        };
+        let file = cli
+            .files
+            .first()
+            .cloned()
+            .or_else(|| cli.pattern.as_ref().map(PathBuf::from))
+            .ok_or_else(|| anyhow::anyhow!("No file specified. Usage: ck --add <file>"))?;
         status.section_header("Adding File to Index");
         status.info(&format!("Processing {}", file.display()));
 
@@ -1124,11 +1114,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
 
     if cli.status || cli.status_verbose || cli.status_json {
         // Handle --status, --status-verbose, and --status-json flags
-        let status_path = cli
-            .files
-            .first()
-            .cloned()
-            .unwrap_or_else(|| PathBuf::from("."));
+        let status_path = cli.command_target_path();
         let verbose = cli.status_verbose;
 
         let stats = if cli.status_json {

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -1087,9 +1087,6 @@ fn test_concurrent_indexing_is_serialized() {
         .unwrap();
     }
 
-    // Note: `--index` resolves its target from the positional pattern slot,
-    // so an explicit path argument would be misparsed (see UNEXPECTED.md).
-    // Run from inside the directory instead.
     let spawn_indexer = || {
         Command::new(ck_binary())
             .arg("--index")
@@ -1173,5 +1170,55 @@ fn test_sigpipe_terminates_silently() {
         status.signal(),
         Some(libc::SIGPIPE),
         "ck should be terminated by SIGPIPE, got status {status:?}"
+    );
+}
+
+/// Command-mode flags must honor an explicit path argument: `ck --index /dir`
+/// parses the path into the positional pattern slot (these commands take no
+/// search pattern) and previously ran against the cwd instead.
+#[test]
+fn test_command_flags_honor_explicit_path() {
+    let target = TempDir::new().unwrap();
+    let elsewhere = TempDir::new().unwrap();
+    fs::write(target.path().join("a.txt"), "indexable content here").unwrap();
+
+    // --index <path> from an unrelated cwd must index <path>, not the cwd
+    let output = Command::new(ck_binary())
+        .args(["--index", target.path().to_str().unwrap()])
+        .current_dir(elsewhere.path())
+        .output()
+        .expect("Failed to run ck --index <path>");
+    assert!(
+        output.status.success(),
+        "ck --index <path> failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        target.path().join(".ck").exists(),
+        "--index must create the index at the given path"
+    );
+    assert!(
+        !elsewhere.path().join(".ck").exists(),
+        "--index must not index the cwd when a path is given"
+    );
+
+    // --status <path> must report the index at <path>
+    let output = Command::new(ck_binary())
+        .args(["--status", target.path().to_str().unwrap()])
+        .current_dir(elsewhere.path())
+        .output()
+        .expect("Failed to run ck --status <path>");
+    assert!(output.status.success());
+
+    // --clean <path> must remove the index at <path>
+    let output = Command::new(ck_binary())
+        .args(["--clean", target.path().to_str().unwrap()])
+        .current_dir(elsewhere.path())
+        .output()
+        .expect("Failed to run ck --clean <path>");
+    assert!(output.status.success());
+    assert!(
+        !target.path().join(".ck").exists(),
+        "--clean must remove the index at the given path"
     );
 }


### PR DESCRIPTION
## Problem

`ck --index /some/repo` silently indexes the **current working directory**, not `/some/repo`. The path lands in the positional *pattern* slot (command-mode flags take no search pattern), `files` stays empty, and every handler defaulted to `.`. `ck --index .` only ever worked by coincidence — the "." pattern was ignored and "." happens to be the default.

Found the hard way: a concurrent-indexing test ran `ck --index <tempdir>` twice and both processes indexed the ck repo itself. This is also the root cause of the ancient `ck --add /tmp/test.txt` → "No file specified" entry in UNEXPECTED.md.

## Fix

New `Cli::command_target_path()` — explicit `files` positionals first, then the pattern slot, then `.` — used by `--index`, `--clean`, `--clean-orphans`, `--status`, `--status-verbose`, `--status-json`, and `--switch-model`. `--add` now uses the same precedence (its old special-case had an unreachable error arm); `--inspect`/`--dump-chunks` already handled the pattern slot correctly.

## Testing

- New integration test `test_command_flags_honor_explicit_path`: runs `--index`, `--status`, `--clean` with an explicit path from an unrelated cwd; asserts the index is created/reported/removed at the *given* path and the cwd is untouched.
- Removed the now-obsolete cwd workaround comment in the concurrent-indexing test.
- Full `ck-search` suite green (28 integration tests), clippy clean, fmt applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)