### PR TITLE
feat(ck-core): add CK_INDEX_DIR to relocate index directories

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "thiserror 1.0.69",
 ]
@@ -491,6 +492,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "tracing",

--- a/README.md
+++ b/README.md
@@ -420,6 +420,23 @@ project/
 
 The `.ck/` directory is a cache — safe to delete and rebuild anytime.
 
+#### Relocating the index (`CK_INDEX_DIR`)
+
+Set the `CK_INDEX_DIR` environment variable to keep indexes out of your source
+tree entirely. Each search root is then indexed under
+`$CK_INDEX_DIR/<basename>-<hash>`, where `<hash>` is derived from the root's
+absolute path so roots that share a name don't collide:
+
+```bash
+export CK_INDEX_DIR="$HOME/.cache/ck"
+ck --index ~/code/project     # index lives in ~/.cache/ck/project-<hash>/
+```
+
+This is handy for keeping repositories free of in-tree `.ck/` directories,
+caching indexes in CI, or sharing one index location across multiple checkouts
+of the same tree. When `CK_INDEX_DIR` is unset, indexes are stored in `.ck/` as
+above.
+
 ## 🧪 Testing
 
 ```bash

--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -513,7 +513,7 @@ async fn run_index_workflow(
     let exclude_patterns = build_exclude_patterns(cli);
 
     if clean_first {
-        let index_dir = path.join(".ck");
+        let index_dir = ck_core::index_dir(path);
         if index_dir.exists() {
             let spinner = status.create_spinner("Removing existing index...");
             ck_index::clean_index(path)?;
@@ -978,7 +978,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
             .map_err(|e| anyhow::anyhow!(e.to_string()))?;
 
         if !cli.force {
-            let manifest_path = path.join(".ck").join("manifest.json");
+            let manifest_path = ck_core::index_dir(&path).join("manifest.json");
             if manifest_path.exists()
                 && let Ok(data) = std::fs::read(&manifest_path)
                 && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
@@ -1143,7 +1143,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
             });
 
             // Add model information if available
-            let manifest_path = status_path.join(".ck").join("manifest.json");
+            let manifest_path = ck_core::index_dir(&status_path).join("manifest.json");
             if let Ok(data) = std::fs::read(&manifest_path)
                 && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
                 && let Some(model_name) = manifest.embedding_model
@@ -1183,7 +1183,7 @@ async fn run_cli_mode(cli: Cli) -> Result<()> {
             status.info(&format!("  Total chunks: {}", stats.total_chunks));
             status.info(&format!("  Embedded chunks: {}", stats.embedded_chunks));
 
-            let manifest_path = status_path.join(".ck").join("manifest.json");
+            let manifest_path = ck_core::index_dir(&status_path).join("manifest.json");
             if let Ok(data) = std::fs::read(&manifest_path)
                 && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
                 && let Some(model_name) = manifest.embedding_model

--- a/ck-cli/src/mcp_server.rs
+++ b/ck-cli/src/mcp_server.rs
@@ -1650,7 +1650,7 @@ impl CkMcpServer {
         let _guard = lock.lock().await;
 
         // Check if index exists and get stats
-        let index_path = path_buf.join(".ck");
+        let index_path = ck_core::index_dir(&path_buf);
         let index_exists = index_path.exists();
 
         let mut index_info = json!({
@@ -1703,7 +1703,7 @@ impl CkMcpServer {
                 index_info["index_size_bytes"] = json!(stats.index_size_bytes);
 
                 // Add model information if available
-                let manifest_path = path_buf.join(".ck").join("manifest.json");
+                let manifest_path = ck_core::index_dir(&path_buf).join("manifest.json");
                 if let Ok(data) = std::fs::read(&manifest_path)
                     && let Ok(manifest) = serde_json::from_slice::<ck_index::IndexManifest>(&data)
                     && let Some(model_name) = manifest.embedding_model

--- a/ck-cli/tests/integration_tests.rs
+++ b/ck-cli/tests/integration_tests.rs
@@ -9,6 +9,14 @@ fn ck_binary() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ck"))
 }
 
+/// Spawn ck with `CK_INDEX_DIR` cleared so these tests exercise the default
+/// in-tree `.ck` behavior they assert on, regardless of the ambient environment.
+fn ck_command() -> Command {
+    let mut cmd = Command::new(ck_binary());
+    cmd.env_remove("CK_INDEX_DIR");
+    cmd
+}
+
 #[test]
 fn test_basic_grep_functionality() {
     let temp_dir = TempDir::new().unwrap();
@@ -31,7 +39,7 @@ fn test_basic_grep_functionality() {
     .unwrap();
 
     // Test basic regex search
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["rust", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -51,7 +59,7 @@ fn test_case_insensitive_search() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-i", "HELLO", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -73,7 +81,7 @@ fn test_recursive_search() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-r", "target", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -89,7 +97,7 @@ fn test_json_output() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.txt"), "json test line").unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--json", "json", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -111,7 +119,7 @@ fn test_index_command() {
     fs::write(temp_dir.path().join("test.txt"), "indexable content").unwrap();
 
     // Test index creation
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -147,7 +155,7 @@ fn test_switch_model_skips_when_same_model() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.rs"), "fn main() {}").unwrap();
 
-    let status = Command::new(ck_binary())
+    let status = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .status()
@@ -156,7 +164,7 @@ fn test_switch_model_skips_when_same_model() {
 
     let updated_before = read_manifest_updated(temp_dir.path());
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--switch-model", "bge-small"])
         .current_dir(temp_dir.path())
         .output()
@@ -183,7 +191,7 @@ fn test_switch_model_force_rebuild() {
     )
     .unwrap();
 
-    let status = Command::new(ck_binary())
+    let status = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .status()
@@ -194,7 +202,7 @@ fn test_switch_model_force_rebuild() {
 
     std::thread::sleep(std::time::Duration::from_secs(1));
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--switch-model", "bge-small", "--force"])
         .current_dir(temp_dir.path())
         .output()
@@ -235,7 +243,7 @@ fn test_semantic_search() {
     .unwrap();
 
     // First create an index
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -244,7 +252,7 @@ fn test_semantic_search() {
     assert!(output.status.success());
 
     // Test semantic search - should rank AI content higher for "neural networks"
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--sem", "neural networks", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -282,7 +290,7 @@ fn test_lexical_search() {
     .unwrap();
 
     // Create index
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -291,7 +299,7 @@ fn test_lexical_search() {
     assert!(output.status.success());
 
     // Test lexical search
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--lex", "machine learning", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -314,7 +322,7 @@ fn test_hybrid_search() {
     .unwrap();
 
     // Create index
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -323,7 +331,7 @@ fn test_hybrid_search() {
     assert!(output.status.success());
 
     // Test hybrid search
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--hybrid", "Python", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -344,7 +352,7 @@ fn test_context_lines() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-C", "1", "target", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck with context");
@@ -371,7 +379,7 @@ fn test_topk_limit() {
         .unwrap();
     }
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--topk", "5", "match", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck with topk");
@@ -391,7 +399,7 @@ fn test_line_numbers() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-n", "matched", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck with line numbers");
@@ -410,7 +418,7 @@ fn test_clean_command() {
     fs::write(temp_dir.path().join("test.txt"), "test content").unwrap();
 
     // Create index first
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -427,7 +435,7 @@ fn test_clean_command() {
     );
 
     // Clean index
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--clean", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -450,7 +458,7 @@ fn test_no_matches_stderr_message() {
     fs::write(temp_dir.path().join("test.txt"), "hello world").unwrap();
 
     // Search for pattern that won't match
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["nonexistent_pattern", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -470,7 +478,7 @@ fn test_no_matches_stderr_message() {
 
 #[test]
 fn test_nonexistent_directory_error() {
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--sem", "test", "/nonexistent/directory"])
         .output()
         .expect("Failed to run ck");
@@ -485,7 +493,7 @@ fn test_nonexistent_directory_error() {
 #[test]
 fn test_error_handling() {
     // Test with nonexistent directory
-    let _output = Command::new(ck_binary())
+    let _output = ck_command()
         .args(["test", "/nonexistent/directory"])
         .output()
         .expect("Failed to run ck");
@@ -497,7 +505,7 @@ fn test_error_handling() {
     let temp_dir = TempDir::new().unwrap();
     fs::write(temp_dir.path().join("test.txt"), "test content").unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["[invalid", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -519,7 +527,7 @@ fn test_invalid_regex_warning_during_highlighting() {
 
     // Test that an invalid regex pattern shows a warning during highlighting
     // The search will fail (as expected), but we should see a warning about the invalid regex
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args([
             "[invalid", // This is an invalid regex pattern
             temp_dir.path().to_str().unwrap(),
@@ -551,7 +559,7 @@ fn test_jsonl_basic_output() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["fn main", "--jsonl", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -594,7 +602,7 @@ fn test_jsonl_no_snippet_flag() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args([
             "fn main",
             "--jsonl",
@@ -635,13 +643,13 @@ fn test_jsonl_vs_regular_output() {
     .unwrap();
 
     // Regular output
-    let regular_output = Command::new(ck_binary())
+    let regular_output = ck_command()
         .args(["fn main", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
 
     // JSONL output
-    let jsonl_output = Command::new(ck_binary())
+    let jsonl_output = ck_command()
         .args(["fn main", "--jsonl", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -682,7 +690,7 @@ fn test_jsonl_with_different_languages() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["main", "--jsonl", temp_dir.path().to_str().unwrap()])
         .output()
         .expect("Failed to run ck");
@@ -725,7 +733,7 @@ fn test_add_single_file_to_index() {
     fs::write(&test_file, "This is test content for indexing").unwrap();
 
     // First create an index in the directory
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -738,7 +746,7 @@ fn test_add_single_file_to_index() {
     fs::write(&new_file, "New file content to be added").unwrap();
 
     // Test adding the new file with absolute path
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--add", new_file.to_str().unwrap()])
         .output()
         .expect("Failed to run ck --add");
@@ -760,7 +768,7 @@ fn test_add_single_file_to_index() {
     );
 
     // Verify the file was actually added by searching for it
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["New file", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -780,7 +788,7 @@ fn test_add_file_with_relative_path() {
     let temp_dir = TempDir::new().unwrap();
 
     // Create index first
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -796,7 +804,7 @@ fn test_add_file_with_relative_path() {
     .unwrap();
 
     // Test adding with relative path from the temp directory
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--add", "relative_file.txt"])
         .current_dir(temp_dir.path())
         .output()
@@ -809,7 +817,7 @@ fn test_add_file_with_relative_path() {
     );
 
     // Verify file was added
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["Relative path", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -839,7 +847,7 @@ fn test_no_ckignore_flag_disables_hierarchical_ignore() {
 
     // Test WITH --no-ckignore flag - .tmp files should be INCLUDED
     // Using -r for recursive grep-style search (no indexing needed)
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-r", "--no-ckignore", "FINDME", "."])
         .current_dir(parent)
         .output()
@@ -859,7 +867,7 @@ fn test_no_ckignore_flag_disables_hierarchical_ignore() {
     );
 
     // Test WITHOUT --no-ckignore flag (default behavior) - .tmp files should be EXCLUDED
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["-r", "FINDME", "."])
         .current_dir(parent)
         .output()
@@ -913,7 +921,7 @@ fn test_mixedbread_index_and_search() {
     .unwrap();
 
     // Test indexing with Mixedbread model
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "--model", "mxbai-xsmall", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -955,7 +963,7 @@ fn test_mixedbread_index_and_search() {
     );
 
     // Test semantic search with Mixedbread
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--sem", "error handling", "--model", "mxbai-xsmall", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -976,7 +984,7 @@ fn test_mixedbread_index_and_search() {
     );
 
     // Test reranking with Mixedbread reranker
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args([
             "--sem",
             "error handling",
@@ -1018,7 +1026,7 @@ fn test_switch_model_to_mixedbread() {
     .unwrap();
 
     // Create index with default model
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -1031,7 +1039,7 @@ fn test_switch_model_to_mixedbread() {
     std::thread::sleep(std::time::Duration::from_secs(1));
 
     // Switch to Mixedbread model
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--switch-model", "mxbai-xsmall"])
         .current_dir(temp_dir.path())
         .output()
@@ -1088,7 +1096,7 @@ fn test_concurrent_indexing_is_serialized() {
     }
 
     let spawn_indexer = || {
-        Command::new(ck_binary())
+        ck_command()
             .arg("--index")
             .current_dir(temp_dir.path())
             .stdout(Stdio::null())
@@ -1140,7 +1148,7 @@ fn test_sigpipe_terminates_silently() {
     let line = "match: the quick brown fox jumps over the lazy dog\n";
     fs::write(temp_dir.path().join("big.txt"), line.repeat(50_000)).unwrap();
 
-    let mut child = Command::new(ck_binary())
+    let mut child = ck_command()
         .args(["match", temp_dir.path().to_str().unwrap()])
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -1183,7 +1191,7 @@ fn test_command_flags_honor_explicit_path() {
     fs::write(target.path().join("a.txt"), "indexable content here").unwrap();
 
     // --index <path> from an unrelated cwd must index <path>, not the cwd
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--index", target.path().to_str().unwrap()])
         .current_dir(elsewhere.path())
         .output()
@@ -1203,7 +1211,7 @@ fn test_command_flags_honor_explicit_path() {
     );
 
     // --status <path> must report the index at <path>
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--status", target.path().to_str().unwrap()])
         .current_dir(elsewhere.path())
         .output()
@@ -1211,7 +1219,7 @@ fn test_command_flags_honor_explicit_path() {
     assert!(output.status.success());
 
     // --clean <path> must remove the index at <path>
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--clean", target.path().to_str().unwrap()])
         .current_dir(elsewhere.path())
         .output()
@@ -1236,7 +1244,7 @@ fn test_lexical_search_reflects_file_changes() {
     )
     .unwrap();
 
-    let status = Command::new(ck_binary())
+    let status = ck_command()
         .args(["--index", "."])
         .current_dir(temp_dir.path())
         .status()
@@ -1244,7 +1252,7 @@ fn test_lexical_search_reflects_file_changes() {
     assert!(status.success());
 
     // First lexical search builds the tantivy index
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--lex", "alphaterm", "."])
         .current_dir(temp_dir.path())
         .env("RUST_LOG", "ck_engine=debug,ck_index=debug")
@@ -1271,7 +1279,7 @@ fn test_lexical_search_reflects_file_changes() {
     )
     .unwrap();
 
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--lex", "zebraterm", "."])
         .current_dir(temp_dir.path())
         .output()
@@ -1285,7 +1293,7 @@ fn test_lexical_search_reflects_file_changes() {
 
     // Modify the original file: removed content must stop matching
     fs::write(temp_dir.path().join("a.txt"), "completely different now").unwrap();
-    let output = Command::new(ck_binary())
+    let output = ck_command()
         .args(["--lex", "alphaterm", "."])
         .current_dir(temp_dir.path())
         .output()

--- a/ck-cli/tests/mcp_tests.rs
+++ b/ck-cli/tests/mcp_tests.rs
@@ -382,8 +382,12 @@ async fn test_mcp_semantic_search_with_missing_files() {
 }
 
 #[tokio::test]
+#[serial_test::serial]
 async fn test_mcp_index_status_reports_real_index_size() {
     use ck_search::IndexStatusRequest;
+    // This test asserts the in-tree `.ck` size, so pin default behavior even if
+    // CK_INDEX_DIR is set in the ambient environment.
+    unsafe { std::env::remove_var("CK_INDEX_DIR") };
 
     let temp_dir = create_test_files().await;
     let server = CkMcpServer::new(temp_dir.path().to_path_buf()).unwrap();

--- a/ck-core/Cargo.toml
+++ b/ck-core/Cargo.toml
@@ -21,3 +21,4 @@ bincode = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3.27"
+serial_test = "2.0"

--- a/ck-core/src/lib.rs
+++ b/ck-core/src/lib.rs
@@ -591,9 +591,129 @@ pub fn build_exclude_patterns(additional_excludes: &[String], use_defaults: bool
     patterns
 }
 
+/// Environment variable that relocates ck's per-root index directories out of
+/// the source tree. See [`index_dir`].
+pub const INDEX_DIR_ENV: &str = "CK_INDEX_DIR";
+
+/// File written inside a relocated index directory recording the absolute
+/// search root it was built for, so a basename-hash collision under
+/// [`INDEX_DIR_ENV`] can be detected rather than silently sharing an index.
+const INDEX_ROOT_MARKER: &str = "root_path";
+
+/// The configured relocation base, or `None` when [`INDEX_DIR_ENV`] is unset or
+/// empty (in which case indexes live in-tree at `<root>/.ck`).
+fn relocation_base() -> Option<PathBuf> {
+    match std::env::var(INDEX_DIR_ENV) {
+        Ok(base) if !base.is_empty() => Some(absolute_for_hash(Path::new(&base))),
+        _ => None,
+    }
+}
+
+/// Best-effort absolute form of `path`, stable across calls but not required to
+/// exist on disk.
+///
+/// Prefers [`std::fs::canonicalize`] (resolves symlinks, requires existence),
+/// falling back to [`std::path::absolute`] (lexical, anchored at the current
+/// directory, no filesystem access), and finally to `path` itself. Never
+/// panics.
+fn absolute_for_hash(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path)
+        .or_else(|_| std::path::absolute(path))
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Returns the directory that holds ck's index and sidecar files for a search
+/// root.
+///
+/// By default this is `<root>/.ck`, keeping the index alongside the data it
+/// describes. When [`INDEX_DIR_ENV`] is set to a non-empty value, the index is
+/// relocated to `$CK_INDEX_DIR/<basename>-<hash8>`, where `<basename>` is the
+/// final component of `root` and `<hash8>` is the first 8 hex characters of the
+/// blake3 hash of the root's absolute path. This keeps repositories free of
+/// in-tree `.ck` directories while giving each root a stable, collision-
+/// resistant location even when two roots share a basename.
+///
+/// Both the relocation base and the root are absolutized, so the returned path
+/// is absolute and independent of the current directory (a relative
+/// `CK_INDEX_DIR` is anchored at the launch directory). The environment
+/// variable is read on every call, so callers (and tests) may change it at
+/// runtime. An empty value is treated as unset. This function never panics: if
+/// a path cannot be made absolute it degrades gracefully (see
+/// [`absolute_for_hash`]).
+pub fn index_dir(root: &Path) -> PathBuf {
+    match relocation_base() {
+        Some(base) => {
+            let abs = absolute_for_hash(root);
+            let basename = abs
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_else(|| "root".to_string());
+            let hash = blake3::hash(abs.to_string_lossy().as_bytes());
+            let hash8 = &hash.to_hex()[..8];
+            base.join(format!("{basename}-{hash8}"))
+        }
+        None => root.join(".ck"),
+    }
+}
+
+/// Returns `true` if the index directory for `root` (see [`index_dir`]) exists.
+pub fn index_exists(root: &Path) -> bool {
+    index_dir(root).exists()
+}
+
+/// Record which search root a relocated index directory belongs to.
+///
+/// A no-op unless the index is relocated via [`INDEX_DIR_ENV`] — an in-tree
+/// `.ck` directory lives under its own root and cannot collide. Callers write
+/// the marker when they create or populate an index directory so a later
+/// [`check_index_root_marker`] can detect a basename-hash collision.
+pub fn write_index_root_marker(root: &Path) -> std::io::Result<()> {
+    if relocation_base().is_none() {
+        return Ok(());
+    }
+    let dir = index_dir(root);
+    std::fs::create_dir_all(&dir)?;
+    std::fs::write(
+        dir.join(INDEX_ROOT_MARKER),
+        absolute_for_hash(root).to_string_lossy().as_bytes(),
+    )
+}
+
+/// Verify that an existing relocated index directory belongs to `root`.
+///
+/// A no-op unless the index is relocated via [`INDEX_DIR_ENV`]. Returns an
+/// error when the directory carries a marker for a different root — a basename
+/// hash collision under `CK_INDEX_DIR` — rather than silently serving another
+/// root's index. A missing marker (no directory yet, or an index built before
+/// markers existed) is tolerated.
+pub fn check_index_root_marker(root: &Path) -> Result<()> {
+    if relocation_base().is_none() {
+        return Ok(());
+    }
+    let dir = index_dir(root);
+    match std::fs::read_to_string(dir.join(INDEX_ROOT_MARKER)) {
+        Ok(stored) => {
+            let expected = absolute_for_hash(root);
+            if stored.trim() == expected.to_string_lossy() {
+                Ok(())
+            } else {
+                Err(CkError::Index(format!(
+                    "index directory {} was built for a different search root ({}), not {}; \
+                     this is a CK_INDEX_DIR basename-hash collision — point CK_INDEX_DIR at a \
+                     different location for one of the roots",
+                    dir.display(),
+                    stored.trim(),
+                    expected.display(),
+                )))
+            }
+        }
+        Err(_) => Ok(()),
+    }
+}
+
 pub fn get_sidecar_path(repo_root: &Path, file_path: &Path) -> PathBuf {
     let relative = file_path.strip_prefix(repo_root).unwrap_or(file_path);
-    let mut sidecar = repo_root.join(".ck");
+    let mut sidecar = index_dir(repo_root);
     sidecar.push(relative);
     let ext = relative
         .extension()
@@ -668,7 +788,7 @@ pub mod pdf {
     /// Get path for cached PDF content
     pub fn get_content_cache_path(repo_root: &Path, file_path: &Path) -> PathBuf {
         let relative = file_path.strip_prefix(repo_root).unwrap_or(file_path);
-        let mut cache_path = repo_root.join(".ck").join("content");
+        let mut cache_path = crate::index_dir(repo_root).join("content");
         cache_path.push(relative);
 
         // Add .txt extension to the cached file
@@ -684,6 +804,7 @@ pub mod pdf {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use serial_test::serial;
         use std::path::PathBuf;
 
         #[test]
@@ -697,7 +818,9 @@ pub mod pdf {
         }
 
         #[test]
+        #[serial]
         fn test_get_content_cache_path() {
+            unsafe { std::env::remove_var(crate::INDEX_DIR_ENV) };
             let repo_root = PathBuf::from("/project");
             let file_path = PathBuf::from("/project/docs/manual.pdf");
 
@@ -709,7 +832,9 @@ pub mod pdf {
         }
 
         #[test]
+        #[serial]
         fn test_get_content_cache_path_no_extension() {
+            unsafe { std::env::remove_var(crate::INDEX_DIR_ENV) };
             let repo_root = PathBuf::from("/project");
             let file_path = PathBuf::from("/project/docs/manual");
 
@@ -721,7 +846,9 @@ pub mod pdf {
         }
 
         #[test]
+        #[serial]
         fn test_get_content_cache_path_relative() {
+            unsafe { std::env::remove_var(crate::INDEX_DIR_ENV) };
             let repo_root = PathBuf::from("/project");
             let file_path = PathBuf::from("docs/manual.pdf"); // Relative path
 
@@ -737,6 +864,7 @@ pub mod pdf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -995,7 +1123,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_sidecar_path() {
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
         let repo_root = PathBuf::from("/home/user/project");
         let file_path = PathBuf::from("/home/user/project/src/main.rs");
 
@@ -1006,7 +1136,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_sidecar_path_no_extension() {
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
         let repo_root = PathBuf::from("/project");
         let file_path = PathBuf::from("/project/README");
 
@@ -1514,5 +1646,188 @@ mod tests {
         // Patterns should be trimmed
         assert!(!patterns.iter().any(|p| p.starts_with(' ')));
         assert!(!patterns.iter().any(|p| p.ends_with(' ')));
+    }
+
+    // Tests that mutate CK_INDEX_DIR are #[serial]: the variable is
+    // process-global and Rust runs tests in parallel threads by default.
+
+    #[test]
+    #[serial]
+    fn test_index_dir_unset_is_dot_ck() {
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+        let root = Path::new("/some/project");
+        assert_eq!(index_dir(root), root.join(".ck"));
+        assert_eq!(
+            get_sidecar_path(root, &root.join("main.rs")).parent(),
+            Some(root.join(".ck").as_path())
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_dir_empty_is_treated_as_unset() {
+        unsafe { std::env::set_var(INDEX_DIR_ENV, "") };
+        let root = Path::new("/some/project");
+        assert_eq!(index_dir(root), root.join(".ck"));
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_dir_set_uses_basename_and_hash() {
+        let base = TempDir::new().unwrap();
+        unsafe { std::env::set_var(INDEX_DIR_ENV, base.path()) };
+
+        let root = TempDir::new().unwrap();
+        let dir = index_dir(root.path());
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+
+        // Recompute the documented formula against the canonicalized base and
+        // root (index_dir absolutizes both).
+        let base_abs = std::fs::canonicalize(base.path()).unwrap();
+        let abs = std::fs::canonicalize(root.path()).unwrap();
+        let basename = abs.file_name().unwrap().to_string_lossy().into_owned();
+        let hash8 = blake3::hash(abs.to_string_lossy().as_bytes()).to_hex()[..8].to_string();
+        let expected = base_abs.join(format!("{basename}-{hash8}"));
+        assert_eq!(dir, expected);
+
+        // Structural checks: absolute, lives directly under the base, 8-hex suffix.
+        assert!(dir.is_absolute());
+        assert_eq!(dir.parent().unwrap(), base_abs);
+        let name = dir.file_name().unwrap().to_string_lossy().into_owned();
+        let suffix = name.rsplit('-').next().unwrap();
+        assert_eq!(suffix.len(), 8);
+        assert!(suffix.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_dir_same_basename_different_roots_differ() {
+        let base = TempDir::new().unwrap();
+        unsafe { std::env::set_var(INDEX_DIR_ENV, base.path()) };
+
+        // Two distinct roots that share the basename "proj" must not collide.
+        let parent_a = TempDir::new().unwrap();
+        let parent_b = TempDir::new().unwrap();
+        let root_a = parent_a.path().join("proj");
+        let root_b = parent_b.path().join("proj");
+        fs::create_dir_all(&root_a).unwrap();
+        fs::create_dir_all(&root_b).unwrap();
+
+        let dir_a = index_dir(&root_a);
+        let dir_b = index_dir(&root_b);
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+
+        assert_ne!(dir_a, dir_b, "same basename must map to distinct dirs");
+        assert!(
+            dir_a
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("proj-")
+        );
+        assert!(
+            dir_b
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("proj-")
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_dir_absolute_base_is_cwd_independent() {
+        // With an absolute CK_INDEX_DIR, a given root maps to the same index dir
+        // regardless of the process's current directory — so the index and its
+        // write lock don't silently fork per cwd.
+        let base = TempDir::new().unwrap();
+        unsafe { std::env::set_var(INDEX_DIR_ENV, base.path()) };
+        let root = TempDir::new().unwrap();
+        let cwd1 = TempDir::new().unwrap();
+        let cwd2 = TempDir::new().unwrap();
+        let original = std::env::current_dir().ok();
+
+        std::env::set_current_dir(cwd1.path()).unwrap();
+        let dir1 = index_dir(root.path());
+        std::env::set_current_dir(cwd2.path()).unwrap();
+        let dir2 = index_dir(root.path());
+        if let Some(orig) = original {
+            let _ = std::env::set_current_dir(orig);
+        }
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+
+        assert_eq!(
+            dir1, dir2,
+            "index_dir must not depend on the current directory"
+        );
+        assert!(dir1.is_absolute());
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_dir_relative_base_is_absolutized() {
+        // A relative CK_INDEX_DIR is anchored at the launch directory and
+        // resolved to an absolute path, rather than a bare relative path that
+        // downstream filesystem and lock operations would resolve against
+        // whatever cwd each happened to run in.
+        let root = TempDir::new().unwrap();
+        unsafe { std::env::set_var(INDEX_DIR_ENV, "rel-index-base") };
+        let dir = index_dir(root.path());
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+
+        assert!(
+            dir.is_absolute(),
+            "relocated index_dir must be absolute even for a relative CK_INDEX_DIR"
+        );
+        assert!(dir.to_string_lossy().contains("rel-index-base"));
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_exists_tracks_index_dir() {
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+        let root = TempDir::new().unwrap();
+        assert!(!index_exists(root.path()));
+        fs::create_dir_all(index_dir(root.path())).unwrap();
+        assert!(index_exists(root.path()));
+    }
+
+    #[test]
+    #[serial]
+    fn test_index_root_marker_noop_when_unset() {
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+        let root = TempDir::new().unwrap();
+        // With no relocation, the marker helpers do nothing and never create a
+        // marker under the in-tree .ck (which can't collide anyway).
+        write_index_root_marker(root.path()).unwrap();
+        assert!(check_index_root_marker(root.path()).is_ok());
+        assert!(!root.path().join(".ck").join("root_path").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_check_index_root_marker_detects_collision() {
+        let base = TempDir::new().unwrap();
+        unsafe { std::env::set_var(INDEX_DIR_ENV, base.path()) };
+        let parent = TempDir::new().unwrap();
+        let root = parent.path().join("proj");
+        fs::create_dir_all(&root).unwrap();
+
+        // A markerless dir, then a self-marked dir, both validate.
+        assert!(check_index_root_marker(&root).is_ok());
+        write_index_root_marker(&root).unwrap();
+        assert!(check_index_root_marker(&root).is_ok());
+
+        // A marker naming a different root (a basename-hash collision) is
+        // rejected rather than silently reused.
+        let dir = index_dir(&root);
+        fs::write(dir.join("root_path"), b"/a/completely/different/root").unwrap();
+        let result = check_index_root_marker(&root);
+        unsafe { std::env::remove_var(INDEX_DIR_ENV) };
+        assert!(
+            result.is_err(),
+            "a marker for a different root must be rejected"
+        );
     }
 }

--- a/ck-engine/src/lib.rs
+++ b/ck-engine/src/lib.rs
@@ -189,7 +189,7 @@ fn find_nearest_index_root(path: &Path) -> Option<StdPathBuf> {
         path
     };
     loop {
-        if current.join(".ck").exists() {
+        if ck_core::index_exists(current) {
             return Some(current.to_path_buf());
         }
         match current.parent() {
@@ -232,7 +232,7 @@ pub(crate) fn resolve_model_from_root(
     use ck_models::ModelRegistry;
 
     let registry = ModelRegistry::default();
-    let index_dir = index_root.join(".ck");
+    let index_dir = ck_core::index_dir(index_root);
     let manifest_path = index_dir.join("manifest.json");
 
     if manifest_path.exists() {
@@ -831,10 +831,13 @@ async fn lexical_search(options: &SearchOptions) -> Result<Vec<SearchResult>> {
         }
     });
 
-    let index_dir = index_root.join(".ck");
+    let index_dir = ck_core::index_dir(&index_root);
     if !index_dir.exists() {
         return Err(CkError::Index("No index found. Run 'ck index' first.".to_string()).into());
     }
+    // Refuse to serve results from an index dir that a different root claimed
+    // via a CK_INDEX_DIR basename-hash collision. No-op in-tree.
+    ck_core::check_index_root_marker(&index_root)?;
 
     let tantivy_index_path = index_dir.join("tantivy_index");
 

--- a/ck-engine/src/semantic_v3.rs
+++ b/ck-engine/src/semantic_v3.rs
@@ -26,13 +26,16 @@ pub async fn semantic_search_v3_with_progress(
         }
     });
 
-    let index_dir = index_root.join(".ck");
+    let index_dir = ck_core::index_dir(&index_root);
     if !index_dir.exists() {
         return Err(CkError::Index(
             "Index creation failed. Please try running 'ck --index' explicitly.".to_string(),
         )
         .into());
     }
+    // Refuse to serve results from an index dir that a different root claimed
+    // via a CK_INDEX_DIR basename-hash collision. No-op in-tree.
+    ck_core::check_index_root_marker(&index_root)?;
 
     if let Some(ref callback) = progress_callback {
         callback("Loading embeddings from sidecar files...");

--- a/ck-index/Cargo.toml
+++ b/ck-index/Cargo.toml
@@ -38,3 +38,4 @@ fastembed = ["ck-embed/fastembed", "ck-chunk/fastembed"]
 mixedbread = ["ck-embed/mixedbread", "ck-chunk/mixedbread"]
 
 [dev-dependencies]
+serial_test = "2.0"

--- a/ck-index/src/lib.rs
+++ b/ck-index/src/lib.rs
@@ -192,7 +192,7 @@ pub fn collect_files(
     path: &Path,
     options: &ck_core::FileCollectionOptions,
 ) -> Result<Vec<PathBuf>> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
 
     if options.respect_gitignore {
         let overrides = build_overrides(path, &options.exclude_patterns)?;
@@ -295,7 +295,7 @@ pub async fn index_directory(
     options: &ck_core::FileCollectionOptions,
     model: Option<&str>,
 ) -> Result<()> {
-    let _lock = acquire_index_write_lock(&path.join(".ck"))?;
+    let _lock = acquire_index_write_lock(&ck_core::index_dir(path))?;
     index_directory_inner(path, compute_embeddings, options, model).await
 }
 
@@ -310,8 +310,13 @@ async fn index_directory_inner(
         "index_directory called with compute_embeddings={}",
         compute_embeddings
     );
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     fs::create_dir_all(&index_dir)?;
+    // Under CK_INDEX_DIR, two roots that share a basename hash to the same dir.
+    // Refuse to write into one already claimed by a different root, then stamp
+    // this root so later searches can detect the collision. No-op in-tree.
+    ck_core::check_index_root_marker(path)?;
+    ck_core::write_index_root_marker(path)?;
 
     let manifest_path = index_dir.join("manifest.json");
     let mut manifest = load_or_create_manifest(&manifest_path)?;
@@ -454,7 +459,7 @@ async fn index_directory_inner(
 
 pub async fn index_file(file_path: &Path, compute_embeddings: bool) -> Result<()> {
     let repo_root = find_repo_root(file_path)?;
-    let index_dir = repo_root.join(".ck");
+    let index_dir = ck_core::index_dir(&repo_root);
     let _lock = acquire_index_write_lock(&index_dir)?;
 
     let manifest_path = index_dir.join("manifest.json");
@@ -505,7 +510,7 @@ pub async fn update_index(
     compute_embeddings: bool,
     options: &ck_core::FileCollectionOptions,
 ) -> Result<()> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     let index_existed = index_dir.exists();
     let _lock = acquire_index_write_lock(&index_dir)?;
     if !index_existed {
@@ -645,7 +650,7 @@ pub async fn update_index(
 }
 
 pub fn clean_index(path: &Path) -> Result<()> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     if !index_dir.exists() {
         return Ok(());
     }
@@ -682,7 +687,7 @@ pub fn cleanup_index(
     path: &Path,
     options: &ck_core::FileCollectionOptions,
 ) -> Result<CleanupStats> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     if !index_dir.exists() {
         return Ok(CleanupStats::default());
     }
@@ -714,7 +719,7 @@ pub fn cleanup_index(
 }
 
 pub fn get_index_stats(path: &Path) -> Result<IndexStats> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     if !index_dir.exists() {
         return Ok(IndexStats::default());
     }
@@ -814,8 +819,12 @@ pub async fn smart_update_index_with_detailed_progress(
     options: &ck_core::FileCollectionOptions,
     model: Option<&str>,
 ) -> Result<UpdateStats> {
-    let index_dir = path.join(".ck");
+    let index_dir = ck_core::index_dir(path);
     let _lock = acquire_index_write_lock(&index_dir)?;
+    // Guard against a CK_INDEX_DIR basename-hash collision before any
+    // destructive rebuild, so a colliding root's index isn't clobbered. No-op
+    // in-tree. The claim is written once the directory is established below.
+    ck_core::check_index_root_marker(path)?;
     let mut stats = UpdateStats::default();
 
     // Set up interrupt handler (only once per process)
@@ -848,6 +857,7 @@ pub async fn smart_update_index_with_detailed_progress(
 
     // Then perform incremental update
     fs::create_dir_all(&index_dir)?;
+    ck_core::write_index_root_marker(path)?;
     let manifest_path = index_dir.join("manifest.json");
     let mut manifest = load_or_create_manifest(&manifest_path)?;
     normalize_manifest_paths(&mut manifest, &repo_root);
@@ -1589,7 +1599,7 @@ fn find_repo_root(path: &Path) -> Result<PathBuf> {
     };
 
     loop {
-        if current.join(".ck").exists() || current.join(".git").exists() {
+        if ck_core::index_exists(current) || current.join(".git").exists() {
             return Ok(current.to_path_buf());
         }
 
@@ -1752,6 +1762,7 @@ pub struct UpdateStats {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
     use std::fs;
     use tempfile::TempDir;
 
@@ -1958,7 +1969,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_cleanup_index() {
+        unsafe { std::env::remove_var(ck_core::INDEX_DIR_ENV) };
         let temp_dir = TempDir::new().unwrap();
         let test_path = temp_dir.path();
 
@@ -2022,7 +2035,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_clean_index_removes_index_dir() {
+        unsafe { std::env::remove_var(ck_core::INDEX_DIR_ENV) };
         let temp_dir = TempDir::new().unwrap();
         let test_path = temp_dir.path();
         let index_dir = test_path.join(".ck");
@@ -2038,7 +2053,9 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_get_index_stats() {
+        unsafe { std::env::remove_var(ck_core::INDEX_DIR_ENV) };
         let temp_dir = TempDir::new().unwrap();
         let test_path = temp_dir.path();
 

--- a/ck-tui/src/commands.rs
+++ b/ck-tui/src/commands.rs
@@ -267,7 +267,7 @@ fn load_chunk_spans(repo_root: &Path, file_path: &Path) -> Result<Vec<IndexedChu
         .strip_prefix(repo_root)
         .unwrap_or(file_path)
         .to_path_buf();
-    let index_dir = repo_root.join(".ck");
+    let index_dir = ck_core::index_dir(repo_root);
     let sidecar_path = index_dir.join(format!("{}.ck", standard_path.display()));
 
     if !sidecar_path.exists() {

--- a/ck-tui/src/preview.rs
+++ b/ck-tui/src/preview.rs
@@ -76,7 +76,7 @@ fn load_chunk_spans(repo_root: &Path, file_path: &Path) -> Result<Vec<IndexedChu
         .strip_prefix(repo_root)
         .unwrap_or(file_path)
         .to_path_buf();
-    let index_dir = repo_root.join(".ck");
+    let index_dir = ck_core::index_dir(repo_root);
     let sidecar_path = index_dir.join(format!("{}.ck", standard_path.display()));
 
     if !sidecar_path.exists() {

--- a/ck-tui/src/utils.rs
+++ b/ck-tui/src/utils.rs
@@ -50,7 +50,7 @@ pub fn find_repo_root(path: &Path) -> Option<PathBuf> {
     };
 
     loop {
-        if current.join(".ck").exists() {
+        if ck_core::index_exists(current) {
             return Some(current.to_path_buf());
         }
         match current.parent() {


### PR DESCRIPTION
## Summary
By default ck stores each search root's index in an in-tree `.ck/` directory. This adds an opt-in `CK_INDEX_DIR` environment variable: when set, a search root R is indexed under `$CK_INDEX_DIR/<basename(R)>-<hash>` (first 8 hex chars of the blake3 hash of R's canonical absolute path, so same-basename roots get distinct directories). When unset, behavior is byte-identical to today.

## Motivation
- Keep repositories free of in-tree `.ck/` directories.
- Cache indexes in CI without polluting the checkout.
- Share one index across multiple checkouts/worktrees of the same tree.

## Implementation
Two documented helpers in ck-core (`index_dir`, `index_exists`) plus an `INDEX_DIR_ENV` const; every `<root>/.ck` computation routes through them, including the walk-up probes, the tantivy meta file, and the index write lock, so all index state co-locates. The env value is absolutized before use so a relative value can't split the lock from the index. Each relocated index directory carries a `root_path` marker naming the root it was built for; indexing and search refuse a directory claimed by a different root, surfacing a clear error rather than silently mixing two roots' data in the (unlikely) event of a hash collision.

## Notes / limitations
- Relocated index directories are not garbage-collected when a root is deleted or moved (run `ck --clean` first, or remove them manually). In-tree `.ck` disappears with the repo; a relocated index does not.
- Set the variable consistently across concurrent invocations of the same root, preferring an absolute path.

## Tests
ck-core units for unset/set/empty/collision/absolutization/marker; env-touching tests serialized with `serial_test` (the crate the test suite already uses); `cargo test --workspace` green both with and without `CK_INDEX_DIR` set; fmt and clippy clean. README documents the variable under "Index Storage".