### PR TITLE
chore(deps): bump tree-sitter-dart to 0.2.0 (with grammar migration)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
 dependencies = [
- "dirs 6.0.0",
+ "dirs",
  "http",
  "indicatif 0.18.4",
  "libc",
@@ -4070,12 +4070,12 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter-dart"
-version = "0.0.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f1f70b80ce41343e14aafcef67b5ba2e9de89587535b4aabbabb8036f4e38a"
+checksum = "325dd1e24ee9ee21111e9c43680ae7d6010aaa9f282b048a99b9c7163c1cf553"
 dependencies = [
  "cc",
- "tree-sitter",
+ "tree-sitter-language",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ tree-sitter-c = "0.24"
 tree-sitter-cpp = "0.23"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-zig = "1.1"
-tree-sitter-dart = "0.0.4"
+tree-sitter-dart = "0.2.0"
 tree-sitter-elixir = "0.3"
 tree-sitter-md = "0.5.3"
 fastembed = { version = "5.13", default-features = false, features = ["hf-hub-rustls-tls", "ort-download-binaries"] }

--- a/ck-chunk/queries/dart/tags.scm
+++ b/ck-chunk/queries/dart/tags.scm
@@ -1,14 +1,15 @@
 ; Dart chunk definitions using tree-sitter queries
+; Node names follow tree-sitter-dart 0.2.0's grammar.
 
 ; Classes, Mixins, Enums
-(class_definition) @definition.class
+(class_declaration) @definition.class
 (mixin_declaration) @definition.class
 (enum_declaration) @definition.class
 
 ; Functions, Methods, Constructors
-(lambda_expression) @definition.function
-(class_member_definition) @definition.method
-; (constructor_signature) @definition.method 
+(function_declaration) @definition.function
+(method_declaration) @definition.method
+(constructor_signature) @definition.method
 
 ; Top-level variables and constants (module-level)
-(local_variable_declaration) @module.text
+(top_level_variable_declaration) @module.text

--- a/ck-chunk/src/lib.rs
+++ b/ck-chunk/src/lib.rs
@@ -371,12 +371,6 @@ fn chunk_generic_with_token_config(text: &str, model_name: Option<&str>) -> Resu
 }
 
 pub(crate) fn tree_sitter_language(language: ParseableLanguage) -> Result<tree_sitter::Language> {
-    // tree-sitter-dart v0.0.4 uses an older API that returns Language directly,
-    // while newer bindings (v0.24+) require calling .into() on a factory struct.
-    if language == ParseableLanguage::Dart {
-        return Ok(tree_sitter_dart::language());
-    }
-
     if language == ParseableLanguage::Markdown {
         return Ok(tree_sitter_md::LANGUAGE.into());
     }
@@ -395,7 +389,7 @@ pub(crate) fn tree_sitter_language(language: ParseableLanguage) -> Result<tree_s
         ParseableLanguage::CSharp => tree_sitter_c_sharp::LANGUAGE,
         ParseableLanguage::Zig => tree_sitter_zig::LANGUAGE,
 
-        ParseableLanguage::Dart => unreachable!("Handled above via early return"),
+        ParseableLanguage::Dart => tree_sitter_dart::LANGUAGE,
 
         ParseableLanguage::Elixir => tree_sitter_elixir::LANGUAGE,
 


### PR DESCRIPTION
Supersedes #144. The dependabot bump alone fails CI because 0.2.0 is a breaking release.

## Changes
- Bump `tree-sitter-dart` 0.0.4 → 0.2.0
- Drop the legacy `language()` factory; use the `LANGUAGE` constant like the other modern bindings
- Update `ck-chunk`'s Dart tree-sitter query for renamed grammar nodes (`class_definition`→`class_declaration`, `class_member_definition`→`method_declaration`, `local_variable_declaration`→`top_level_variable_declaration`, plus function/constructor captures)

## Validation
- 53/53 ck-chunk tests pass (incl. `dart_queries_capture_core_constructs`)
- fmt + clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)