### PR TITLE
fix(ck-cli): don't reduce the search root past the operands' shared parent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 - **`--hidden` flag** (re-implements #97, original by @peterkc): Include hidden (dot-prefixed) files and directories in both search and indexing. Off by default to preserve current behavior; when set, the file walker no longer skips dot-prefixed entries. Composes with `--no-ignore`/`--no-ckignore` (independent toggles). Threads through `SearchOptions.hidden` and `FileCollectionOptions.show_hidden` to the `ignore` crate's `WalkBuilder.hidden(!show_hidden)` in `ck-index::collect_files`.
 
+### Fixed
+- **Search root no longer escapes past the operands' shared parent** (#184): `ck <query> docs/ notes.md` — a directory operand plus a file that lives beside it rather than inside it — rooted the search/index walk at the filesystem root and walked everything. In `find_search_root`, when the candidate was an *ancestor* of the current root, a loop walked that candidate up one parent at a time looking for an ancestor contained by the (deeper) root — a condition that never held, so it ran to `/`, which the root then adopted. The reduction now takes the longest common prefix of the paths' components, so the root is the operands' actual shared parent. The old behavior was operand-order dependent and surfaced as an apparent hang, or as `Read-only file system (os error 30)` when creating an index at `/`. Note this does not change the root for operands whose *only* shared component is `/` (e.g. `ck <query> /tmp/a /var/b`), where the shared parent genuinely is the filesystem root.
+
 ## [0.7.11] - 2026-05-24
 
 ### Added

--- a/UNEXPECTED.md
+++ b/UNEXPECTED.md
@@ -74,6 +74,12 @@ This file tracks instances where ck behaves unexpectedly during testing or usage
 **Status:** Fixed (fix/command-flag-paths — command-mode flags now resolve their target from the pattern slot via `Cli::command_target_path`; covers `--index`, `--clean`, `--clean-orphans`, `--status*`, `--switch-model`, `--add`)
 **Notes:** Found while writing a concurrent-indexing test: two `ck --index <tempdir>` processes silently indexed the ck repo itself (cwd). Command-mode flags (`--index`, `--clean`, `--add`, …) should treat the first positional arg as their target path.
 
+**Command:** `ck needle docs notes.md` (a directory operand plus a file beside it)
+**Expected:** Search limited to `docs/` and `notes.md`
+**Actual:** The walk was rooted at `/` and traversed the entire filesystem — an apparent hang, or `DETAILED ERROR: Read-only file system (os error 30)` when ck tried to create an index at `/`. Order-dependent: `ck needle notes.md docs` (file operand first) returned instantly. Found after a `ck` process spent 4.5 hours walking a mounted cloud-storage directory, downloading files as it went.
+**Date:** 2026-07-28
+**Status:** Fixed (#184 — `find_search_root` now reduces to the operands' longest common path prefix instead of walking a path up one parent at a time)
+
 ---
 
 ## Instructions

--- a/ck-cli/src/main.rs
+++ b/ck-cli/src/main.rs
@@ -429,7 +429,7 @@ fn find_search_root(include_patterns: &[IncludePattern]) -> PathBuf {
     };
 
     for pattern in include_patterns.iter().skip(1) {
-        let mut candidate = if pattern.is_dir {
+        let candidate = if pattern.is_dir {
             pattern.path.clone()
         } else {
             pattern.path.parent().unwrap_or(&pattern.path).to_path_buf()
@@ -438,27 +438,31 @@ fn find_search_root(include_patterns: &[IncludePattern]) -> PathBuf {
         if candidate.starts_with(&root) {
             continue;
         }
-
-        while !root.starts_with(&candidate) && !candidate.starts_with(&root) {
-            if let Some(parent) = root.parent() {
-                root = parent.to_path_buf();
-            } else {
-                break;
-            }
-        }
-
-        if !candidate.starts_with(&root) {
-            while let Some(parent) = candidate.parent() {
-                if parent.starts_with(&root) {
-                    candidate = parent.to_path_buf();
-                    break;
-                }
-                candidate = parent.to_path_buf();
-            }
-        }
-
+        // The candidate is an ancestor of the current root: widen to it. This
+        // previously fell through to a loop that walked the candidate up to
+        // "/" before the root adopted it.
         if root.starts_with(&candidate) {
             root = candidate;
+            continue;
+        }
+
+        // Neither path contains the other: reduce to their longest shared
+        // prefix, rather than walking either path up one parent at a time.
+        let shared: PathBuf = root
+            .components()
+            .zip(candidate.components())
+            .take_while(|(a, b)| a == b)
+            .map(|(a, _)| a)
+            .collect();
+
+        // An empty reduction means the two paths share no component at all:
+        // relative operands under different directories, or differing Windows
+        // drive prefixes. (Absolute Unix paths always share the root
+        // component.) Keep the current root, which covers one operand, rather
+        // than falling through to the cwd fallback below, which would cover
+        // neither.
+        if !shared.as_os_str().is_empty() {
+            root = shared;
         }
     }
 
@@ -1849,6 +1853,162 @@ mod tests {
 
     use crate::path_utils::{self, expand_glob_patterns_with_base};
     use tempfile::tempdir;
+
+    #[test]
+    fn test_find_search_root_does_not_escape_to_filesystem_root() {
+        // `ck <query> docs/ notes.md` -- a directory operand plus a file whose
+        // parent is an ANCESTOR of it. The search root must be their shared
+        // parent, never "/", and must not depend on operand order.
+        let temp_dir = tempdir().unwrap();
+        let base = temp_dir.path().canonicalize().unwrap();
+        let docs = base.join("docs");
+        fs::create_dir_all(&docs).unwrap();
+        let notes = base.join("notes.md");
+        fs::write(&notes, "needle\n").unwrap();
+
+        let dir_first = vec![
+            IncludePattern {
+                path: docs.clone(),
+                is_dir: true,
+            },
+            IncludePattern {
+                path: notes.clone(),
+                is_dir: false,
+            },
+        ];
+        let file_first = vec![
+            IncludePattern {
+                path: notes,
+                is_dir: false,
+            },
+            IncludePattern {
+                path: docs,
+                is_dir: true,
+            },
+        ];
+
+        assert_eq!(find_search_root(&dir_first), base, "dir operand first");
+        assert_eq!(find_search_root(&file_first), base, "file operand first");
+    }
+
+    #[test]
+    fn test_find_search_root_unrelated_subtrees_use_shared_prefix() {
+        // Neither operand contains the other and their shared prefix is deeper
+        // than "/", so this exercises the prefix reduction itself rather than
+        // the containment fast paths.
+        let temp_dir = tempdir().unwrap();
+        let base = temp_dir.path().canonicalize().unwrap();
+        let deep = base.join("x").join("deep");
+        let other = base.join("y");
+        fs::create_dir_all(&deep).unwrap();
+        fs::create_dir_all(&other).unwrap();
+        let other_file = other.join("other.md");
+        fs::write(&other_file, "needle\n").unwrap();
+
+        let patterns = vec![
+            IncludePattern {
+                path: deep,
+                is_dir: true,
+            },
+            IncludePattern {
+                path: other_file,
+                is_dir: false,
+            },
+        ];
+        assert_eq!(find_search_root(&patterns), base);
+    }
+
+    #[test]
+    fn test_find_search_root_three_operands_are_order_independent() {
+        // The reduction is a fold, so the result must not depend on the order
+        // the operands arrive in.
+        let temp_dir = tempdir().unwrap();
+        let base = temp_dir.path().canonicalize().unwrap();
+        let a = base.join("a").join("deep");
+        let b = base.join("b");
+        let c = base.join("c").join("nested");
+        for d in [&a, &b, &c] {
+            fs::create_dir_all(d).unwrap();
+        }
+
+        let mk = |p: &std::path::Path| IncludePattern {
+            path: p.to_path_buf(),
+            is_dir: true,
+        };
+        let orders = [
+            vec![mk(&a), mk(&b), mk(&c)],
+            vec![mk(&c), mk(&a), mk(&b)],
+            vec![mk(&b), mk(&c), mk(&a)],
+        ];
+        for patterns in orders {
+            assert_eq!(find_search_root(&patterns), base);
+        }
+    }
+
+    #[test]
+    fn test_find_search_root_no_shared_component_keeps_first_operand() {
+        // Operands sharing no component at all reduce to nothing. Rather than
+        // falling through to the "." fallback -- which would search neither --
+        // the first operand's root is kept, so at least one is covered.
+        // Reachable on any platform with relative operands; also the differing
+        // Windows drive prefix case.
+        let patterns = vec![
+            IncludePattern {
+                path: PathBuf::from("a/x"),
+                is_dir: true,
+            },
+            IncludePattern {
+                path: PathBuf::from("b/y"),
+                is_dir: true,
+            },
+        ];
+        assert_eq!(find_search_root(&patterns), PathBuf::from("a/x"));
+    }
+
+    #[test]
+    fn test_find_search_root_disjoint_operands_share_only_root() {
+        // These paths are intentionally notional -- find_search_root operates
+        // purely textually, so they need not exist on disk.
+        // Operands under different top-level directories genuinely share only
+        // "/", so that is the correct common parent — this reduction narrows
+        // the root to the shared prefix, it does not bound how wide that
+        // prefix may legitimately be.
+        let patterns = vec![
+            IncludePattern {
+                path: PathBuf::from("/tmp/docs"),
+                is_dir: true,
+            },
+            IncludePattern {
+                path: PathBuf::from("/var/notes.md"),
+                is_dir: false,
+            },
+        ];
+        assert_eq!(find_search_root(&patterns), PathBuf::from("/"));
+    }
+
+    #[test]
+    fn test_find_search_root_reduces_siblings_to_common_ancestor() {
+        // Two sibling directories still reduce to the directory containing
+        // them -- the ordinary common-ancestor case.
+        let temp_dir = tempdir().unwrap();
+        let base = temp_dir.path().canonicalize().unwrap();
+        let a = base.join("a");
+        let b = base.join("b");
+        fs::create_dir_all(&a).unwrap();
+        fs::create_dir_all(&b).unwrap();
+
+        let patterns = vec![
+            IncludePattern {
+                path: a,
+                is_dir: true,
+            },
+            IncludePattern {
+                path: b,
+                is_dir: true,
+            },
+        ];
+        assert_eq!(find_search_root(&patterns), base);
+    }
 
     #[test]
     fn test_expand_glob_patterns_supports_semicolon_lists() {


### PR DESCRIPTION
## The bug

`ck <query> docs/ notes.md` — a directory operand plus a file beside it — roots the walk at `/` and traverses the whole filesystem. On current `main`:

```bash
mkdir -p /tmp/ckdemo/docs && cd /tmp/ckdemo
echo needle > docs/a.txt; echo needle > notes.md
ck needle docs notes.md      # hangs — walking /
ck needle notes.md docs      # instant (order-dependent)
```

Where `/` isn't writable it surfaces as `Read-only file system (os error 30)` instead — ck trying to index `/`. I found it after a ck process spent 4.5h walking a mounted cloud drive, downloading files as it went.

## Cause

In `find_search_root()`, when the candidate is an *ancestor* of the current root, the second loop walks the candidate up looking for an ancestor contained by the (deeper) root — a condition that never holds, so it runs to `/`, which the trailing `if root.starts_with(&candidate)` then adopts.

## Fix

Reduce to the operands' longest common path prefix instead of walking either path up one parent at a time. Both containment fast-paths are kept as short-circuits.

## Scope

This makes the root the operands' actual shared parent; it doesn't bound how wide that parent may legitimately be. `ck <query> /tmp/a /var/b` still roots at `/`, because `/` genuinely is their shared parent — unchanged here, and pinned by a test. If you'd want disjoint operands handled differently (per-operand walks, or an error), that's a separate behavioral decision.

## Verification

Six unit tests, including both operand orders and order-independence for N>2. Differential-tested against the old walk over 500k random operand sets: narrower in some, **broader in none**. `cargo test` (91), `clippy`, `fmt` clean. CHANGELOG + UNEXPECTED.md entries included.

## Two things worth your call

- **Operands sharing no component** (relative `a/x` + `b/y`, or differing Windows drives) reduce to nothing. I keep the current root so one operand is still covered, rather than the old fall-through to `.` which covered neither. The dropped operand is silent — happy to add a warning if you'd prefer.
- **The containment fast-paths are strictly redundant** with the reduction (verified exhaustively). Kept as an optimization; happy to collapse the loop body if you'd rather have the smaller code.